### PR TITLE
Fix usage examples in doc

### DIFF
--- a/source/assets/ndcfillingrectangle.ts
+++ b/source/assets/ndcfillingrectangle.ts
@@ -12,6 +12,7 @@ import { Initializable } from '../core/initializable';
  * a vertex array object (from geometry base class), and provides a specialized draw call for rendering. It is intended
  * for, e.g., viewport/screen-filling rendering in post-processing. The vertices can be used directly as normalized
  * device space (NDC) coordinates, e.g., by using the following vertex shader snippet:
+ *
  * ```
  * #if __VERSION__ == 100
  *     attribute vec2 a_vertex;

--- a/source/core/program.ts
+++ b/source/core/program.ts
@@ -10,6 +10,7 @@ import { Shader } from './shader';
 /**
  * WebGL Program wrapper encapsulating program creation, shader attachment, linking, binding, as well as attribute and
  * uniform location retrieval. A program is intended to be used as follows:
+ *
  * ```
  * this.program.initialize(
  *  [('screenaligned.vert', require('../shaders/screenaligned.vert'))],

--- a/source/core/shader.ts
+++ b/source/core/shader.ts
@@ -8,6 +8,7 @@ import { AbstractObject } from './object';
 /**
  * WebGL shader wrapper encapsulating shader creation, compilation, and deletion. A shader can be attached to multiple
  * Programs for linking, and can be deleted if detached from all (linked) programs.
+ *
  * ```
  * var frag = new gloperate.Shader(context, context.gl.FRAGMENT_SHADER, 'EmptyFragmentShader');
  * var vert = new gloperate.Shader(context, context.gl.VERTEX_SHADER, 'EmptyVertexShader');


### PR DESCRIPTION
Sometimes an empty line is required for the code snippet to render correctly, see e.g. https://www.webgl-operate.org/doc/classes/ndcfillingrectangle.html