### PR TITLE
Fix IE11 polyfill for String.prototype.startsWith

### DIFF
--- a/source/polyfill.ts
+++ b/source/polyfill.ts
@@ -4,7 +4,7 @@
  */
 if (String.prototype.startsWith === undefined) {
     /* tslint:disable-next-line:space-before-function-paren */
-    String.prototype.startsWith = (searchString, position): boolean => {
+    String.prototype.startsWith = function (searchString, position): boolean {
         position = position || 0;
         return this.indexOf(searchString, position) === position;
     };


### PR DESCRIPTION
It failed with `Object doesn't support property or method 'indexOf'` because an arrow function is not appropriate here.