### PR TITLE
Touch event provider

### DIFF
--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -104,7 +104,7 @@ export class Canvas extends Resizable {
     /** @see {@link mouseEventProvider} */
     protected _mouseEventProvider: MouseEventProvider;
 
-    /** @see {@link TouchEventProvider} */
+    /** @see {@link touchEventProvider} */
     protected _touchEventProvider: TouchEventProvider;
 
 

--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -14,8 +14,8 @@ import { Controller } from './controller';
 import { MouseEventProvider } from './mouseeventprovider';
 import { Renderer } from './renderer';
 import { Resizable } from './resizable';
-import { Wizard } from './wizard';
 import { TouchEventProvider } from './toucheventprovider';
+import { Wizard } from './wizard';
 
 
 /**

--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -15,6 +15,7 @@ import { MouseEventProvider } from './mouseeventprovider';
 import { Renderer } from './renderer';
 import { Resizable } from './resizable';
 import { Wizard } from './wizard';
+import { TouchEventProvider } from './toucheventprovider';
 
 
 /**
@@ -103,6 +104,9 @@ export class Canvas extends Resizable {
     /** @see {@link mouseEventProvider} */
     protected _mouseEventProvider: MouseEventProvider;
 
+    /** @see {@link TouchEventProvider} */
+    protected _touchEventProvider: TouchEventProvider;
+
 
     /**
      * Create and initialize a multi-frame controller, setup a default multi-frame number and get the canvas's webgl
@@ -130,6 +134,7 @@ export class Canvas extends Resizable {
         this._element = element instanceof HTMLCanvasElement ? element :
             document.getElementById(element) as HTMLCanvasElement;
         this._mouseEventProvider = new MouseEventProvider(this._element, 200);
+        this._touchEventProvider = new TouchEventProvider(this._element, 200);
 
         const dataset = this._element.dataset;
 
@@ -322,7 +327,7 @@ export class Canvas extends Resizable {
          * method is assigned to the pipelines invalidation event.
          */
         this._renderer.initialize(this.context, (force) => this._controller.update(force),
-            this._mouseEventProvider /*, this._keyEventProvider, this._touchEventProvider */);
+            this._mouseEventProvider /*, this._keyEventProvider */, this._touchEventProvider);
 
         this._renderer.frameSize = this._frameSize;
         this._renderer.clearColor = this._clearColor.rgba;
@@ -646,4 +651,10 @@ export class Canvas extends Resizable {
         return this._mouseEventProvider;
     }
 
+    /**
+     * Canvas touch event provider referring to the canvas element.
+     */
+    get touchEventProvider(): TouchEventProvider {
+        return this._touchEventProvider;
+    }
 }

--- a/source/debug/testnavigation.ts
+++ b/source/debug/testnavigation.ts
@@ -12,7 +12,7 @@ export class TestNavigation {
 
 
     constructor(invalidate: Invalidate, mouseEventProvider: MouseEventProvider) {
-        this._eventHandler = new EventHandler(invalidate, mouseEventProvider);
+        this._eventHandler = new EventHandler(invalidate, mouseEventProvider, undefined);
         this._eventHandler.pushMouseEnterHandler((latests: Array<MouseEvent>, previous: Array<MouseEvent>) =>
             this.onMouseEnter(latests, previous));
         this._eventHandler.pushMouseLeaveHandler((latests: Array<MouseEvent>, previous: Array<MouseEvent>) =>

--- a/source/eventhandler.ts
+++ b/source/eventhandler.ts
@@ -7,8 +7,9 @@ import { Observable, Subscription } from 'rxjs';
 import { assert } from './auxiliaries';
 
 import { MouseEventProvider } from './mouseeventprovider';
-import { TouchEventProvider } from './toucheventprovider';
 import { Invalidate } from './renderer';
+import { TouchEventProvider } from './toucheventprovider';
+
 
 /**
  * Callback for handling mouse events, given the latest mouse events (since last update) as well as the previous.
@@ -19,6 +20,7 @@ export interface MouseEventHandler { (latests: Array<MouseEvent>, previous: Arra
  * Callback for handling touch events, given the latest touch events (since last update) as well as the previous.
  */
 export interface TouchEventHandler { (latests: Array<TouchEvent>, previous: Array<TouchEvent>): void; }
+
 
 /**
  * ... Provider and event handler are explicitly separated in order to reduce the number of observables (reuse of event
@@ -227,9 +229,7 @@ export class EventHandler {
 
         } else if (event instanceof TouchEvent) {
             const e = event as TouchEvent;
-            /* tslint:disable-next-line:prefer-for-of */
-            for (let i = 0; i < e.touches.length; ++i) {
-                const touch = e.touches[i];
+            for (const touch of e.touches) {
                 offsets.push(vec2.fromValues(touch.clientX, touch.clientY));
             }
         }
@@ -346,6 +346,7 @@ export class EventHandler {
     pushTouchCancelHandler(handler: TouchEventHandler) {
         this.pushTouchEventHandler(TouchEventProvider.Type.Cancel, handler);
     }
+
 
     requestPointerLock(): void {
         if (this._mouseEventProvider) {

--- a/source/mouseeventprovider.ts
+++ b/source/mouseeventprovider.ts
@@ -41,6 +41,12 @@ export class MouseEventProvider {
     /** @see {@link pointerLock} */
     protected _pointerLockRequestPending = false;
 
+    /**
+     * This mask saves for which types of events, event.preventDefault should be called.
+     * This is useful to disallow some kinds of standard events like scrolling or clicking on links.
+     */
+    protected _preventDefaultMask: MouseEventProvider.PreventDefaultOption;
+
     constructor(element: HTMLCanvasElement, timeframe?: number) {
         assert(element !== undefined, `expected valid canvas element on initialization, given ${element}`);
         this._element = element;
@@ -60,6 +66,37 @@ export class MouseEventProvider {
             return;
         }
         PointerLock.request(this._element);
+    }
+
+    /**
+     * Add one option to the mask of events for which preventDefault should be called.
+     * @param option Option to be added
+     */
+    addPreventDefaultOption(option: MouseEventProvider.PreventDefaultOption): void {
+        this._preventDefaultMask |= option;
+    }
+
+    /**
+     * Remove one option to the mask of events for which preventDefault should be called.
+     * @param option Option to be removed
+     */
+    removePreventDefaultOption(option: MouseEventProvider.PreventDefaultOption): void {
+        this._preventDefaultMask &= ~option;
+    }
+
+    /**
+     * Set the whole mask, which represents for which preventDefault should be called.
+     * Overrides all previously set options.
+     * @param mask Mask of options for which preventDefault should be called
+     */
+    set preventDefaultMask(mask: MouseEventProvider.PreventDefaultOption) {
+        this._preventDefaultMask = mask;
+    }
+
+    protected handlePreventDefault(option: MouseEventProvider.PreventDefaultOption, event: MouseEvent) {
+        if (this._preventDefaultMask & option) {
+            event.preventDefault();
+        }
     }
 
     observable(type: MouseEventProvider.Type): Observable<MouseEvent> | Observable<WheelEvent> {
@@ -101,8 +138,11 @@ export class MouseEventProvider {
     get clickObservable(): Observable<MouseEvent> {
         if (this._clickSubject === undefined) {
             this._clickSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._clickListener = (event: MouseEvent) => this._clickSubject.next(event);
-            this._element.onclick = this._clickListener;
+            this._clickListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.Click, event);
+                this._clickSubject.next(event);
+            }
+            this._element.addEventListener('click', this._clickListener);
         }
         return this._clickSubject.asObservable();
     }
@@ -110,8 +150,11 @@ export class MouseEventProvider {
     get enterObservable(): Observable<MouseEvent> {
         if (this._enterSubject === undefined) {
             this._enterSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._enterListener = (event: MouseEvent) => this._enterSubject.next(event);
-            this._element.onmouseenter = this._enterListener;
+            this._enterListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.MouseEnter, event);
+                this._enterSubject.next(event);
+            }
+            this._element.addEventListener('mouseenter', this._enterListener);
         }
         return this._enterSubject.asObservable();
     }
@@ -119,8 +162,11 @@ export class MouseEventProvider {
     get leaveObservable(): Observable<MouseEvent> {
         if (this._leaveSubject === undefined) {
             this._leaveSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._leaveListener = (event: MouseEvent) => this._leaveSubject.next(event);
-            this._element.onmouseleave = this._leaveListener;
+            this._leaveListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.MouseLeave, event);
+                this._leaveSubject.next(event);
+            }
+            this._element.addEventListener('mouseleave', this._leaveListener);
         }
         return this._leaveSubject.asObservable();
     }
@@ -128,8 +174,11 @@ export class MouseEventProvider {
     get downObservable(): Observable<MouseEvent> {
         if (this._downSubject === undefined) {
             this._downSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._downListener = (event: MouseEvent) => this._downSubject.next(event);
-            this._element.onmousedown = this._downListener;
+            this._downListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.MouseDown, event);
+                this._downSubject.next(event);
+            }
+            this._element.addEventListener('mousedown', this._downListener);
         }
         return this._downSubject.asObservable();
     }
@@ -137,8 +186,11 @@ export class MouseEventProvider {
     get upObservable(): Observable<MouseEvent> {
         if (this._upSubject === undefined) {
             this._upSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._upListener = (event: MouseEvent) => this._upSubject.next(event);
-            this._element.onmouseup = this._upListener;
+            this._upListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.MouseUp, event);
+                this._upSubject.next(event);
+            }
+            this._element.addEventListener('mouseup', this._upListener);
         }
         return this._upSubject.asObservable();
     }
@@ -146,8 +198,11 @@ export class MouseEventProvider {
     get moveObservable(): Observable<MouseEvent> {
         if (this._moveSubject === undefined) {
             this._moveSubject = new ReplaySubject<MouseEvent>(undefined, this._timeframe);
-            this._moveListener = (event: MouseEvent) => this._moveSubject.next(event);
-            this._element.onmousemove = this._moveListener;
+            this._moveListener = (event: MouseEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.MouseMove, event);
+                this._moveSubject.next(event);
+            }
+            this._element.addEventListener('mousemove', this._moveListener);
         }
         return this._moveSubject.asObservable();
     }
@@ -155,8 +210,11 @@ export class MouseEventProvider {
     get wheelObservable(): Observable<WheelEvent> {
         if (this._wheelSubject === undefined) {
             this._wheelSubject = new ReplaySubject<WheelEvent>(undefined, this._timeframe);
-            this._wheelListener = (event: WheelEvent) => this._wheelSubject.next(event);
-            this._element.onwheel = this._wheelListener;
+            this._wheelListener = (event: WheelEvent) => {
+                this.handlePreventDefault(MouseEventProvider.PreventDefaultOption.Wheel, event);
+                this._wheelSubject.next(event);
+            }
+            this._element.addEventListener('wheel', this._wheelListener);
         }
         return this._wheelSubject.asObservable();
     }
@@ -167,5 +225,16 @@ export class MouseEventProvider {
 export namespace MouseEventProvider {
 
     export enum Type { Click, Enter, Leave, Down, Up, Move, Wheel }
+
+    export enum PreventDefaultOption {
+        None = 0,
+        Click = 1 << 0,
+        MouseUp = 1 << 1,
+        MouseDown = 1 << 2,
+        MouseMove = 1 << 3,
+        MouseEnter = 1 << 4,
+        MouseLeave = 1 << 5,
+        Wheel = 1 << 6
+    }
 
 }

--- a/source/navigation.ts
+++ b/source/navigation.ts
@@ -64,7 +64,7 @@ export class Navigation {
         this._invalidate = invalidate;
 
         /* Create event handler that listens to mouse events. */
-        this._eventHandler = new EventHandler(invalidate, mouseEventProvider);
+        this._eventHandler = new EventHandler(invalidate, mouseEventProvider, undefined);
 
         /* Listen to mouse events. */
         this._eventHandler.pushMouseDownHandler((latests: Array<MouseEvent>, previous: Array<MouseEvent>) =>

--- a/source/renderer.ts
+++ b/source/renderer.ts
@@ -11,6 +11,7 @@ import { Context } from './context';
 import { Controllable } from './controller';
 import { Initializable } from './initializable';
 import { MouseEventProvider } from './mouseeventprovider';
+import { TouchEventProvider } from './toucheventprovider';
 import { GLclampf4, GLfloat2, GLsizei2, tuple2 } from './tuples';
 import { Wizard } from './wizard';
 
@@ -155,7 +156,7 @@ export abstract class Renderer extends Initializable implements Controllable {
     protected abstract onInitialize(context: Context, callback: Invalidate,
         mouseEventProvider: MouseEventProvider | undefined,
         /* keyEventProvider: KeyEventProvider | undefined, */
-        /* touchEventProvider: TouchEventProvider | undefined */): boolean;
+        touchEventProvider: TouchEventProvider | undefined): boolean;
 
     /**
      * Actual uninitialize call specified by inheritor.
@@ -210,14 +211,14 @@ export abstract class Renderer extends Initializable implements Controllable {
     initialize(context: Context, callback: Invalidate,
         mouseEventProvider: MouseEventProvider | undefined,
         /* keyEventProvider: KeyEventProvider | undefined, */
-        /* touchEventProvider: TouchEventProvider | undefined */): boolean {
+        touchEventProvider: TouchEventProvider | undefined): boolean {
 
         assert(context !== undefined, `valid webgl context required`);
         this._context = context;
         assert(callback !== undefined, `valid multi-frame update callback required`);
         this._invalidate = callback;
 
-        return this.onInitialize(context, callback, mouseEventProvider);
+        return this.onInitialize(context, callback, mouseEventProvider, touchEventProvider);
     }
 
     /**

--- a/source/toucheventprovider.ts
+++ b/source/toucheventprovider.ts
@@ -32,7 +32,7 @@ export class TouchEventProvider {
      * This mask saves for which types of events, event.preventDefault should be called.
      * This is useful to disallow some kinds of standard events like scrolling or clicking on links.
      */
-    protected _preventDefaultMask: TouchEventProvider.Type;
+    protected _preventDefaultMask: TouchEventProvider.PreventDefaultOption;
 
     constructor(element: HTMLCanvasElement, timeframe?: number) {
         assert(element !== undefined, `expected valid canvas element on initialization, given ${element}`);
@@ -40,7 +40,7 @@ export class TouchEventProvider {
         this._timeframe = timeframe;
     }
 
-    protected handlePreventDefault(option: TouchEventProvider.Type, event: TouchEvent) {
+    protected handlePreventDefault(option: TouchEventProvider.PreventDefaultOption, event: TouchEvent) {
         if (this._preventDefaultMask & option) {
             event.preventDefault();
         }
@@ -50,7 +50,7 @@ export class TouchEventProvider {
      * Add one option to the mask of events for which preventDefault should be called.
      * @param option Option to be added
      */
-    addPreventDefaultOption(option: TouchEventProvider.Type): void {
+    addPreventDefaultOption(option: TouchEventProvider.PreventDefaultOption): void {
         this._preventDefaultMask |= option;
     }
 
@@ -58,7 +58,7 @@ export class TouchEventProvider {
      * Remove one option to the mask of events for which preventDefault should be called.
      * @param option Option to be removed
      */
-    removePreventDefaultOption(option: TouchEventProvider.Type): void {
+    removePreventDefaultOption(option: TouchEventProvider.PreventDefaultOption): void {
         this._preventDefaultMask &= ~option;
     }
 
@@ -67,7 +67,7 @@ export class TouchEventProvider {
      * Overrides all previously set options.
      * @param mask Mask of options for which preventDefault should be called
      */
-    set preventDefaultMask(mask: TouchEventProvider.Type) {
+    set preventDefaultMask(mask: TouchEventProvider.PreventDefaultOption) {
         this._preventDefaultMask = mask;
     }
 
@@ -92,7 +92,7 @@ export class TouchEventProvider {
         if (this._startSubject === undefined) {
             this._startSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
             this._startListener = (event: TouchEvent) => {
-                this.handlePreventDefault(TouchEventProvider.Type.Start, event);
+                this.handlePreventDefault(TouchEventProvider.PreventDefaultOption.Start, event);
                 this._startSubject.next(event);
             };
             this._element.addEventListener('touchstart', this._startListener);
@@ -104,7 +104,7 @@ export class TouchEventProvider {
         if (this._endSubject === undefined) {
             this._endSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
             this._endListener = (event: TouchEvent) => {
-                this.handlePreventDefault(TouchEventProvider.Type.End, event);
+                this.handlePreventDefault(TouchEventProvider.PreventDefaultOption.End, event);
                 this._endSubject.next(event);
             };
             this._element.addEventListener('touchend', this._endListener);
@@ -116,7 +116,7 @@ export class TouchEventProvider {
         if (this._moveSubject === undefined) {
             this._moveSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
             this._moveListener = (event: TouchEvent) => {
-                this.handlePreventDefault(TouchEventProvider.Type.Move, event);
+                this.handlePreventDefault(TouchEventProvider.PreventDefaultOption.Move, event);
                 this._moveSubject.next(event);
             };
             this._element.addEventListener('touchmove', this._moveListener);
@@ -128,7 +128,7 @@ export class TouchEventProvider {
         if (this._cancelSubject === undefined) {
             this._cancelSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
             this._cancelListener = (event: TouchEvent) => {
-                this.handlePreventDefault(TouchEventProvider.Type.Cancel, event);
+                this.handlePreventDefault(TouchEventProvider.PreventDefaultOption.Cancel, event);
                 this._cancelSubject.next(event);
             };
             this._element.addEventListener('touchcancel', this._cancelListener);
@@ -140,7 +140,9 @@ export class TouchEventProvider {
 
 export namespace TouchEventProvider {
 
-    export enum Type {
+    export enum Type { Start, End, Move, Cancel }
+
+    export enum PreventDefaultOption {
         None = 0,
         Start = 1 << 0,
         End = 1 << 1,

--- a/source/toucheventprovider.ts
+++ b/source/toucheventprovider.ts
@@ -1,0 +1,150 @@
+
+import { Observable, ReplaySubject } from 'rxjs';
+
+import { assert } from './auxiliaries';
+
+
+export class TouchEventProvider {
+
+    /**
+     * HTML canvas element within the HTML5 document to register event listeners to.
+     */
+    protected _element: HTMLCanvasElement;
+
+    /**
+     * Time frame for events to be buffered (windowTime in rxjs per ReplaySubject).
+     */
+    protected _timeframe: number | undefined;
+
+    protected _startListener: { (event: TouchEvent): void };
+    protected _startSubject: ReplaySubject<TouchEvent>;
+
+    protected _endListener: { (event: TouchEvent): void };
+    protected _endSubject: ReplaySubject<TouchEvent>;
+
+    protected _moveListener: { (event: TouchEvent): void };
+    protected _moveSubject: ReplaySubject<TouchEvent>;
+
+    protected _cancelListener: { (event: TouchEvent): void };
+    protected _cancelSubject: ReplaySubject<TouchEvent>;
+
+    /**
+     * This mask saves for which types of events, event.preventDefault should be called.
+     * This is useful to disallow some kinds of standard events like scrolling or clicking on links.
+     */
+    protected _preventDefaultMask: TouchEventProvider.Type;
+
+    constructor(element: HTMLCanvasElement, timeframe?: number) {
+        assert(element !== undefined, `expected valid canvas element on initialization, given ${element}`);
+        this._element = element;
+        this._timeframe = timeframe;
+    }
+
+    protected handlePreventDefault(option: TouchEventProvider.Type, event: TouchEvent) {
+        if (this._preventDefaultMask & option) {
+            event.preventDefault();
+        }
+    }
+
+    /**
+     * Add one option to the mask of events for which preventDefault should be called.
+     * @param option Option to be added
+     */
+    addPreventDefaultOption(option: TouchEventProvider.Type): void {
+        this._preventDefaultMask |= option;
+    }
+
+    /**
+     * Remove one option to the mask of events for which preventDefault should be called.
+     * @param option Option to be removed
+     */
+    removePreventDefaultOption(option: TouchEventProvider.Type): void {
+        this._preventDefaultMask &= ~option;
+    }
+
+    /**
+     * Set the whole mask, which represents for which preventDefault should be called.
+     * Overrides all previously set options.
+     * @param mask Mask of options for which preventDefault should be called
+     */
+    set preventDefaultMask(mask: TouchEventProvider.Type) {
+        this._preventDefaultMask = mask;
+    }
+
+    observable(type: TouchEventProvider.Type): Observable<TouchEvent> {
+        /* tslint:disable-next-line:switch-default */
+        switch (type) {
+            case TouchEventProvider.Type.Start:
+                return this.startObservable;
+            case TouchEventProvider.Type.End:
+                return this.endObservable;
+            case TouchEventProvider.Type.Move:
+                return this.moveObservable;
+            case TouchEventProvider.Type.Cancel:
+                return this.cancelObservable;
+        }
+
+        assert(false, 'Encountered unknown touch event.');
+        return new Observable<TouchEvent>();
+    }
+
+    get startObservable(): Observable<TouchEvent> {
+        if (this._startSubject === undefined) {
+            this._startSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
+            this._startListener = (event: TouchEvent) => {
+                this.handlePreventDefault(TouchEventProvider.Type.Start, event);
+                this._startSubject.next(event);
+            };
+            this._element.addEventListener('touchstart', this._startListener);
+        }
+        return this._startSubject.asObservable();
+    }
+
+    get endObservable(): Observable<TouchEvent> {
+        if (this._endSubject === undefined) {
+            this._endSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
+            this._endListener = (event: TouchEvent) => {
+                this.handlePreventDefault(TouchEventProvider.Type.End, event);
+                this._endSubject.next(event);
+            };
+            this._element.addEventListener('touchend', this._endListener);
+        }
+        return this._endSubject.asObservable();
+    }
+
+    get moveObservable(): Observable<TouchEvent> {
+        if (this._moveSubject === undefined) {
+            this._moveSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
+            this._moveListener = (event: TouchEvent) => {
+                this.handlePreventDefault(TouchEventProvider.Type.Move, event);
+                this._moveSubject.next(event);
+            };
+            this._element.addEventListener('touchmove', this._moveListener);
+        }
+        return this._moveSubject.asObservable();
+    }
+
+    get cancelObservable(): Observable<TouchEvent> {
+        if (this._cancelSubject === undefined) {
+            this._cancelSubject = new ReplaySubject<TouchEvent>(undefined, this._timeframe);
+            this._cancelListener = (event: TouchEvent) => {
+                this.handlePreventDefault(TouchEventProvider.Type.Cancel, event);
+                this._cancelSubject.next(event);
+            };
+            this._element.addEventListener('touchcancel', this._cancelListener);
+        }
+        return this._cancelSubject.asObservable();
+    }
+}
+
+
+export namespace TouchEventProvider {
+
+    export enum Type {
+        None = 0,
+        Start = 1 << 0,
+        End = 1 << 1,
+        Move = 1 << 2,
+        Cancel = 1 << 3,
+    }
+}

--- a/source/webgl-operate.slim.ts
+++ b/source/webgl-operate.slim.ts
@@ -9,6 +9,7 @@ export { ContextMasquerade } from './contextmasquerade';
 export { ExtensionsHash } from './extensionshash';
 export { ChangeLookup } from './changelookup';
 export { MouseEventProvider } from './mouseeventprovider';
+export { TouchEventProvider } from './toucheventprovider';
 export { EventHandler } from './eventhandler';
 
 export { Buffer } from './buffer';


### PR DESCRIPTION
This includes #87, so only merge after that is resolved.
There is some code duplication, e.g. for `pushTouchEventHandler` and `pushMouseEventHandler`. I could not find a good way to resolve this with Typescript generics.
Maybe instead we could introduce a base class EventProvider?