### PR TITLE
Call swap after resizing

### DIFF
--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -269,6 +269,7 @@ export class Canvas extends Resizable {
 
         if (this._renderer) {
             this._controller.unblock();
+            this._renderer.swap();
         }
     }
 

--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -269,6 +269,7 @@ export class Canvas extends Resizable {
 
         if (this._renderer) {
             this._controller.unblock();
+            /* Swapping here fixes flickering while resizing the canvas for safari. */
             this._renderer.swap();
         }
     }


### PR DESCRIPTION
This fixes flickering while resizing the canvas for safari