### PR TITLE
Fix label alignment

### DIFF
--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -30,6 +30,7 @@ export class Position2DLabel extends Label {
         this._position = vec2.fromValues(0.0, 0.0);
         this._direction = vec2.fromValues(1.0, 0.0);
 
+        this._fontSize = 20;
         this._fontSizeUnit = Label.SpaceUnit.Px;
     }
 

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -34,6 +34,7 @@ export class Position3DLabel extends Label {
         this._direction = vec3.fromValues(1.0, 0.0, 0.0);
         this._up = vec3.fromValues(0.0, 1.0, 0.0);
 
+        this._fontSize = 0.05;
         this._fontSizeUnit = Label.SpaceUnit.World;
     }
 

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -116,7 +116,7 @@ export class Typesetter {
         }
 
         /* Origin is expected to be in typesetting space (not transformed yet). */
-        for (let i = begin; i < end; ++i) {
+        for (let i = begin; i <= end; ++i) {
             glyphs.vertices[i].origin[0] += penOffset;
         }
     }


### PR DESCRIPTION
When label alignment was set on "Right" or "Center", the last glyph of the label was not typeset correctly.