### PR TITLE
make fontface an optional parameter for label creation

### DIFF
--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -292,15 +292,14 @@ namespace debug {
         }
 
         /**
-         * Sets up an example scene with 2D and 3D labels and sets the corresponding data on LabelGeometries.
+         * Sets up an example scene with 2D and 3D labels and sets the corresponding data on LabelGeometries. The
+         * FontFace is set on each label by the LabelRenderPass.
          */
         protected setupScene(): void {
 
             /** OpenLL 3D Labels */
 
-            const placeholderFontFace = new FontFace(this._context, `FontfacePlaceholder`);
-
-            const pos3Dlabel = new Position3DLabel(new Text('Hello Position 3D!'), placeholderFontFace);
+            const pos3Dlabel = new Position3DLabel(new Text('Hello Position 3D!'));
             pos3Dlabel.fontSize = 0.1;
 
             /* position values in world, since fontSizeUnit is set to SpaceUnit.World */
@@ -308,20 +307,20 @@ namespace debug {
             pos3Dlabel.setDirection(0.0, 1.0, 0.0);
             pos3Dlabel.setUp(-1.0, 0.0, 0.0);
 
-            const shadowPos3Dlabel = new Position3DLabel(new Text('Hello Position Shadow'), placeholderFontFace);
+            const shadowPos3Dlabel = new Position3DLabel(new Text('Hello Position Shadow'));
             shadowPos3Dlabel.setPosition(0.0, 0.1, -0.5);
             shadowPos3Dlabel.fontSize = 0.1;
             shadowPos3Dlabel.setDirection(0.0, 1.0, 0.0);
             shadowPos3Dlabel.setUp(0.0, 0.0, -1.0);
 
-            const anotherPos3Dlabel = new Position3DLabel(new Text('Yet another 3D Label'), placeholderFontFace);
+            const anotherPos3Dlabel = new Position3DLabel(new Text('Yet another 3D Label'));
             anotherPos3Dlabel.setPosition(0.2, -0.1, 0.0);
             anotherPos3Dlabel.setDirection(-1.0, 0.0, 0.0);
             anotherPos3Dlabel.setUp(0.0, -1.0, 0.0);
 
             /** OpenLL 2D Labels */
 
-            const pos2Dlabel = new Position2DLabel(new Text('Hello Position 2D!'), placeholderFontFace);
+            const pos2Dlabel = new Position2DLabel(new Text('Hello Position 2D!'));
             pos2Dlabel.fontSize = 40;
 
             /* position values in px, since fontSizeUnit is set to SpaceUnit.Px */

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -64,14 +64,17 @@ export class Label {
     /**
      * Constructs an unconfigured, empty label.
      * @param text - The text that is displayed by this label.
-     * @param fontFace - The font face that should be used for that label.
+     * @param fontFace - The font face that should be used for that label, or undefined if set later.
      */
-    constructor(text: Text, fontFace: FontFace) {
+    constructor(text: Text, fontFace?: FontFace) {
         this._text = text;
-        this._fontFace = fontFace;
         this._transform = mat4.create();
         this._userTransform = mat4.create();
         this._extent = [0, 0];
+
+        if (fontFace) {
+            this._fontFace = fontFace;
+        }
     }
 
     /**
@@ -268,7 +271,8 @@ export class Label {
     }
 
     /**
-     * Font face used for typesetting, transformation, and rendering.
+     * Font face used for typesetting, transformation, and rendering. The font face is usually set by the
+     * LabelRenderPass.
      */
     set fontFace(fontFace: FontFace) {
         if (this._fontFace === fontFace) {

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -38,7 +38,7 @@ export class Label {
     protected _fontSizeUnit: Label.SpaceUnit = Label.SpaceUnit.World;
 
     /** @see {@link fontFace} */
-    protected _fontFace: FontFace;
+    protected _fontFace: FontFace | undefined;
 
     /** @see {@link color} */
     protected _color: Color;
@@ -130,7 +130,7 @@ export class Label {
         if (index < 1 || index > this.length) {
             return NaN;
         }
-        return this._fontFace.kerning(this.charCodeAt(index - 1), this.charCodeAt(index));
+        return this._fontFace!.kerning(this.charCodeAt(index - 1), this.charCodeAt(index));
     }
 
     /**
@@ -142,7 +142,7 @@ export class Label {
         if (index < 0 || index > this.length - 1) {
             return NaN;
         }
-        return this._fontFace.kerning(this.charCodeAt(index), this.charCodeAt(index + 1));
+        return this._fontFace!.kerning(this.charCodeAt(index), this.charCodeAt(index + 1));
     }
 
     /**
@@ -155,7 +155,7 @@ export class Label {
         if (index < 0 || index > this.length) {
             return NaN;
         }
-        return this._fontFace.glyph(this.charCodeAt(index)).advance;
+        return this._fontFace!.glyph(this.charCodeAt(index)).advance;
     }
 
 
@@ -274,7 +274,7 @@ export class Label {
      * Font face used for typesetting, transformation, and rendering. The font face is usually set by the
      * LabelRenderPass.
      */
-    set fontFace(fontFace: FontFace) {
+    set fontFace(fontFace: FontFace | undefined) {
         if (this._fontFace === fontFace) {
             return;
         }
@@ -282,7 +282,7 @@ export class Label {
         this._altered.alter('resources');
         this._fontFace = fontFace;
     }
-    get fontFace(): FontFace {
+    get fontFace(): FontFace | undefined {
         return this._fontFace;
     }
 
@@ -329,7 +329,7 @@ export class Label {
     }
     get transform(): mat4 {
 
-        const s = this.fontSize / this._fontFace.size;
+        const s = this.fontSize / this._fontFace!.size;
 
         const t: mat4 = mat4.create();
         mat4.scale(t, this._transform, vec3.fromValues(s, s, s));

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -1,7 +1,7 @@
 
 import { mat4, vec2, vec3, vec4 } from 'gl-matrix';
 
-import { log, LogLevel } from '../auxiliaries';
+import { assert, log, LogLevel } from '../auxiliaries';
 
 import { FontFace } from './fontface';
 import { GlyphVertices } from './glyphvertices';
@@ -23,9 +23,9 @@ export class Position2DLabel extends Label {
     /**
      * Constructs a pre-configured 2D-label with given text
      * @param text - The text that is displayed by this label.
-     * @param identifier - Meaningful name for identification of this instances VAO and VBOs.
+     * @param fontFace - The font face that should be used for that label, or undefined if set later.
      */
-    constructor(text: Text, fontFace: FontFace) {
+    constructor(text: Text, fontFace?: FontFace) {
         super(text, fontFace);
         this._position = vec2.fromValues(0.0, 0.0);
         this._direction = vec2.fromValues(1.0, 0.0);
@@ -42,6 +42,7 @@ export class Position2DLabel extends Label {
      */
     typeset(frameSize: [number, number]): GlyphVertices {
         /** @todo assert: this.fontSizeUnit === Label.SpaceUnit.Px or, later, === Label.SpaceUnit.Pt */
+        assert(!!this.fontFace, `expected a font face for this label before typesetting`);
 
         /** @todo meaningful margins from label.margins or config.margins ? */
         const margins: vec4 = vec4.create();

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -1,7 +1,7 @@
 
 import { mat4, vec3 } from 'gl-matrix';
 
-import { log, LogLevel } from '../auxiliaries';
+import { assert, log, LogLevel } from '../auxiliaries';
 
 import { FontFace } from './fontface';
 import { GlyphVertices } from './glyphvertices';
@@ -26,9 +26,9 @@ export class Position3DLabel extends Label {
     /**
      * Constructs a pre-configured 3D-label with given text.
      * @param text - The text that is displayed by this label.
-     * @param fontFace - The font face that should be used for that label.
+     * @param fontFace - The font face that should be used for that label, or undefined if set later.
      */
-    constructor(text: Text, fontFace: FontFace) {
+    constructor(text: Text, fontFace?: FontFace) {
         super(text, fontFace);
         this._position = vec3.fromValues(0.0, 0.0, 0.0);
         this._direction = vec3.fromValues(1.0, 0.0, 0.0);
@@ -45,6 +45,7 @@ export class Position3DLabel extends Label {
      */
     typeset(): GlyphVertices {
         /** @todo assert: this.fontSizeUnit === Label.SpaceUnit.World */
+        assert(!!this.fontFace, `expected a font face for this label before typesetting`);
 
         const transform = mat4.create();
         const normal = vec3.create();

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -248,6 +248,8 @@ export class Typesetter {
      * @param begin vertex index to start the typesetting (usually 0)
      */
     static typeset(label: Label, glyphs?: GlyphVertices, begin?: number): GLfloat2 {
+        assert(!!label.fontFace, `expected a font face for label before typesetting`);
+
         /* Horizontal and vertical position at which typesetting takes place/arrived. */
         const pen = vec2.create();
 

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -84,7 +84,7 @@ export class Typesetter {
      */
     protected static backward(label: Label, index: number, begin: number, pen: vec2, extent: vec2): void {
         while (index > begin) {
-            const precedingGlyph = label.fontFace.glyph(label.charCodeAt(index));
+            const precedingGlyph = label.fontFace!.glyph(label.charCodeAt(index));
             if (precedingGlyph.depictable()) {
                 break;
             }
@@ -92,7 +92,7 @@ export class Typesetter {
             --index;
         }
         extent[0] = Math.max(pen[0], extent[1]);
-        extent[1] += label.fontFace.lineHeight;
+        extent[1] += label.fontFace!.lineHeight;
     }
 
     /**
@@ -139,19 +139,19 @@ export class Typesetter {
         let offset = 0.0;
         switch (label.lineAnchor) {
             case Label.LineAnchor.Ascent:
-                offset = label.fontFace.ascent;
+                offset = label.fontFace!.ascent;
                 break;
             case Label.LineAnchor.Center:
-                offset = label.fontFace.size * 0.5 + label.fontFace.descent;
+                offset = label.fontFace!.size * 0.5 + label.fontFace!.descent;
                 break;
             case Label.LineAnchor.Descent:
-                offset = label.fontFace.descent;
+                offset = label.fontFace!.descent;
                 break;
             case Label.LineAnchor.Top:
-                offset = label.fontFace.base;
+                offset = label.fontFace!.base;
                 break;
             case Label.LineAnchor.Bottom:
-                offset = label.fontFace.base - label.fontFace.lineHeight;
+                offset = label.fontFace!.base - label.fontFace!.lineHeight;
                 break;
             case Label.LineAnchor.Baseline:
             default:
@@ -266,7 +266,7 @@ export class Typesetter {
 
         let index = iBegin;
         for (; index !== iEnd; ++index) {
-            const glyph = label.fontFace.glyph(label.charCodeAt(index));
+            const glyph = label.fontFace!.glyph(label.charCodeAt(index));
 
             /* Handle line feeds as well as word wrap for next word (or next glyph if word exceeds the line width). */
             const feedLine = label.lineFeedAt(index) || (label.wordWrap &&
@@ -279,7 +279,7 @@ export class Typesetter {
                 Typesetter.transformAlignment(pen, label.alignment, glyphs, feedVertexIndex, vertexIndex);
 
                 pen[0] = 0.0;
-                pen[1] -= label.fontFace.lineHeight;
+                pen[1] -= label.fontFace!.lineHeight;
 
                 feedVertexIndex = vertexIndex;
 
@@ -288,7 +288,7 @@ export class Typesetter {
             }
 
             /* Add and configure data for rendering the current character/glyph of the label. */
-            Typesetter.transformGlyph(label.fontFace, pen, glyph, glyphs ? glyphs.vertices[vertexIndex++] : undefined);
+            Typesetter.transformGlyph(label.fontFace!, pen, glyph, glyphs ? glyphs.vertices[vertexIndex++] : undefined);
 
             pen[0] += glyph.advance;
         }


### PR DESCRIPTION
Currently, `Labels` need a `FontFace` as a parameter of their constructor, but a `FontFace` can only be created after (asynchronously) loading a font asset. That means that it is not possible to create a set of labels while concurrently loading the font asset.

Before, the `LabelRenderer`'s workaround was to use a placeholder fontface until a valid fontface is loaded. However, this is not possible for other applications or outside classes that cannot access a valid rendering `Context`.

With this PR, it is optional to have a valid font face at the time of label creation. The LabelRenderPass sets the valid font face, and the typesetter checks if a label has a valid font face before typesetting.