### PR TITLE
cope with undefined labels in labelrenderpass

### DIFF
--- a/source/text/labelrenderpass.ts
+++ b/source/text/labelrenderpass.ts
@@ -79,6 +79,8 @@ export class LabelRenderPass extends Initializable {
         this._geometry2D = new LabelGeometry(this._context, 'LabelRenderGeometry2D');
 
         this._color = new Color([0.5, 0.5, 0.5], 1.0);
+
+        this._labels = new Array<Label>();
     }
 
     /**
@@ -92,26 +94,14 @@ export class LabelRenderPass extends Initializable {
             return;
         }
 
-        if (this._labels === undefined) {
-            console.log('labels are undefined');
-            const empty = new Float32Array(0);
-            this._geometry2D.update(empty, empty, empty, empty);
-            this._geometry3D.update(empty, empty, empty, empty);
-            return;
-        }
-
         /* Remove all calculated vertices for 2D and 3D labels. */
         const glyphs2D = new GlyphVertices(0);
         const glyphs3D = new GlyphVertices(0);
-
-        console.log('prepare');
-        console.log(this._font);
 
         const frameSize = this._camera.viewport;
         console.log(this._labels);
         for (const label of this._labels) {
             label.fontFace = this._font!;
-            console.log(label);
 
             if (label instanceof Position2DLabel) {
                 glyphs2D.concat(label.typeset(frameSize));
@@ -337,8 +327,6 @@ export class LabelRenderPass extends Initializable {
      * preparation will be invoked on update, iff the labels or the font face have changed.
      */
     set labels(labels: Array<Label>) {
-        console.log('set labels');
-        console.log(labels);
         this._labels = labels;
         this._altered.alter('labels');
     }

--- a/source/text/labelrenderpass.ts
+++ b/source/text/labelrenderpass.ts
@@ -329,6 +329,8 @@ export class LabelRenderPass extends Initializable {
      * preparation will be invoked on update, iff the labels or the font face have changed.
      */
     set labels(labels: Array<Label>) {
+        console.log('set labels');
+        console.log(labels);
         this._labels = labels;
         this._altered.alter('labels');
     }

--- a/source/text/labelrenderpass.ts
+++ b/source/text/labelrenderpass.ts
@@ -96,9 +96,14 @@ export class LabelRenderPass extends Initializable {
         const glyphs2D = new GlyphVertices(0);
         const glyphs3D = new GlyphVertices(0);
 
+        console.log('prepare');
+        console.log(this._font);
+
         const frameSize = this._camera.viewport;
+        console.log(this._labels);
         for (const label of this._labels) {
             label.fontFace = this._font!;
+            console.log(label);
 
             if (label instanceof Position2DLabel) {
                 glyphs2D.concat(label.typeset(frameSize));

--- a/source/text/labelrenderpass.ts
+++ b/source/text/labelrenderpass.ts
@@ -1,7 +1,7 @@
 
 import { mat4 } from 'gl-matrix';
 
-import { assert } from '../auxiliaries';
+import { assert, log, LogLevel } from '../auxiliaries';
 import { GLfloat2 } from '../tuples';
 
 import { Camera } from '../camera';
@@ -99,8 +99,12 @@ export class LabelRenderPass extends Initializable {
         const glyphs3D = new GlyphVertices(0);
 
         const frameSize = this._camera.viewport;
-        console.log(this._labels);
+
         for (const label of this._labels) {
+            if (label === undefined) {
+                log(LogLevel.Warning, `skip undefined label`);
+                continue;
+            }
             label.fontFace = this._font!;
 
             if (label instanceof Position2DLabel) {

--- a/source/text/labelrenderpass.ts
+++ b/source/text/labelrenderpass.ts
@@ -92,6 +92,14 @@ export class LabelRenderPass extends Initializable {
             return;
         }
 
+        if (this._labels === undefined) {
+            console.log('labels are undefined');
+            const empty = new Float32Array(0);
+            this._geometry2D.update(empty, empty, empty, empty);
+            this._geometry3D.update(empty, empty, empty, empty);
+            return;
+        }
+
         /* Remove all calculated vertices for 2D and 3D labels. */
         const glyphs2D = new GlyphVertices(0);
         const glyphs3D = new GlyphVertices(0);


### PR DESCRIPTION
`prepare()` might be called before `this._labels` is defined. So initialize `this._labels` as an empty array.

Furthermore, how should the LabelRenderPass treat undefined labels within its `this._labels`? Skip without logging, skip with logging, assert+stop, or just let it crash because it is the user's fault?

Please ignore the commits that just added console outputs, as they will be removed and the commits will be squashed.