### PR TITLE
refine async font loading

### DIFF
--- a/pugconfig.js
+++ b/pugconfig.js
@@ -22,8 +22,6 @@ const assets = [
     ['./source', buildDir, ['data/{colorbrewer,smithwalt}.json'], [], false],
     ['./node_modules/rxjs/bundles/', `${buildDir}/js`, ['rxjs.umd.min.js'], [], false],
     ['./source/data/', `${buildDir}/data`, ['*'], [], false],
-    ['./source/data/opensansr144', `${buildDir}/data/opensansr144`, ['*'], [], false],
-    ['./source/data/verdana', `${buildDir}/data/verdana`, ['*'], [], false],
 ];
 
 

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -1,5 +1,5 @@
 
-import { assert } from '../auxiliaries';
+import { assert, log, LogLevel } from '../auxiliaries';
 
 import { vec3 } from 'gl-matrix';
 
@@ -147,10 +147,12 @@ namespace debug {
             this._labelPass.camera = this._camera;
             this._labelPass.target = this._intermediateFBO;
 
-            FontFace.fromFile('./data/opensansr144.fnt', context).then((fontFace) => {
-                this._labelPass.fontFace = fontFace;
-                this.invalidate();
-            });
+            FontFace.fromFile('./data/opensansr144.fnt', context)
+                .then((fontFace) => {
+                    this._labelPass.fontFace = fontFace;
+                    this.invalidate();
+                })
+                .catch((reason) => log(LogLevel.Error, reason));
 
             this.setupScene();
 
@@ -158,7 +160,7 @@ namespace debug {
         }
 
         /**
-         * Uninitializes Buffers, Textures and and Programm.
+         * Uninitializes Buffers, Textures, and Program.
          */
         protected onUninitialize(): void {
             super.uninitialize();

--- a/source/fetch.ts
+++ b/source/fetch.ts
@@ -10,17 +10,14 @@ namespace fetch {
 
     export interface FetchTransform<T> { (data: any): T | undefined; }
 
-
     /**
      * Creates a promise for an asynchronous xml/http request on a given URL. If an URL is fetched successfully, the
-     * promise is resolved with a transform to the typed object. An error code and message can be caught otherwise.
+     * promise is resolved with the fetched data.
      * @param url - Uniform resource locator string referencing a file.
      * @param type - Request response type.
-     * @param transform - Callback to a function that transforms the fetched data into an instance of targeted type.
      * @returns - A promise that resolves on a parsed object if successful.
      */
-    export function fetchAsync<T>(url: string, type: XMLHttpRequestResponseType,
-        transform: FetchTransform<T>): Promise<T> {
+    export function fetchAsync<T>(url: string, type: XMLHttpRequestResponseType): Promise<T> {
 
         const response = new Promise<T>((resolve, reject) => {
             const request = new XMLHttpRequest();
@@ -32,14 +29,7 @@ namespace fetch {
                     reject(failed(url, request));
                     return;
                 }
-
-                const data = request.response;
-                const object = transform(data);
-                if (object === undefined) {
-                    reject(`fetching '${url}' failed (TransformError): transforming the object failed.`);
-                    return;
-                }
-                resolve(object);
+                resolve(request.response);
             };
 
             request.onerror = () => reject(failed(url, request));
@@ -99,6 +89,7 @@ namespace fetch {
         });
         return response;
     }
+
 
 }
 

--- a/source/text/fontface.ts
+++ b/source/text/fontface.ts
@@ -1,5 +1,5 @@
 
-import { assert } from '../auxiliaries';
+import { assert, log, LogLevel } from '../auxiliaries';
 import { GLfloat2, GLfloat4, GLsizei2 } from '../tuples';
 
 import { Context } from '../context';
@@ -77,17 +77,16 @@ export class FontFace {
      * @param identifier - Meaningful name/prefix for identification of fetched pages (glyph atlases).
      */
     static fromFile(url: string, context: Context, headless: boolean = false, identifier?: string):
-        Promise<FontFace | undefined> {
+        Promise<FontFace> {
 
-        let fetchedData: any;
-        const transform = (data: any): FontFace => {
-            fetchedData = data;
-            return new FontFace(context, identifier);
+        const transform = (data: any): PromiseLike<FontFace> => {
+            const font = new FontFace(context, identifier);
+            return FontFaceLoader.process(font, data, url, headless)
+                .then((fontFace: FontFace) => fontFace)
+                .catch((reason: any) => Promise.reject(`processing font face data failed: ${reason}`));
         };
 
-        return fetchAsync<FontFace | undefined>(url, 'text', transform)
-            .then((font: FontFace) =>
-                FontFaceLoader.process(font, fetchedData, url, headless));
+        return fetchAsync<FontFace>(url, 'text').then(transform);
     }
 
     /**

--- a/source/text/fontfaceloader.ts
+++ b/source/text/fontfaceloader.ts
@@ -99,7 +99,8 @@ export class FontFaceLoader {
         let page = pairs.get('file')!;
         page = page.replace(/['"]+/g, ''); /* remove quotes */
 
-        return fontFace.glyphTexture.load(`${path}/${page}`);
+        return fontFace.glyphTexture.load(`${path}/${page}`)
+            .catch(() => Promise.reject(`page '${page}' referenced in font file '${url}' was not found`));
     }
 
     /**
@@ -270,11 +271,8 @@ export class FontFaceLoader {
 
         /* Multiple promises might be invoked (one per page due to async texture2D load). Since this is a non async
         transform intended to be used in a async fetch, waiting on all promises here. */
-        return Promise.all(promises)
-            .then((results: Array<void>) => fontFace)
-            .catch((reason) => {
-                log(LogLevel.Warning, `processing font face data failed: ${reason}`);
-                return undefined;
-            });
+        return Promise.all(promises).then(() => fontFace);
     }
+
+
 }

--- a/source/texture2d.ts
+++ b/source/texture2d.ts
@@ -1,5 +1,5 @@
 
-import { assert } from './auxiliaries';
+import { assert, log, LogLevel } from './auxiliaries';
 import { byteSizeOfFormat } from './formatbytesizes';
 import { GLsizei2 } from './tuples';
 
@@ -148,7 +148,10 @@ export class Texture2D extends AbstractObject<WebGLTexture> implements Bindable 
     load(url: string, crossOrigin: boolean = false): Promise<void> {
         return new Promise((resolve, reject) => {
             const image = new Image();
-            image.onerror = () => reject();
+            image.onerror = () => {
+                log(LogLevel.Error, `loading image from '${image.src}' failed`);
+                reject();
+            };
 
             image.onload = () => {
                 this.resize(image.width, image.height);

--- a/website/js/website.js
+++ b/website/js/website.js
@@ -13,7 +13,7 @@ window.onload = function () {
     aboutCode = window.document.getElementById('context-about');
     aboutCode.innerText = context.aboutString();
 
-    canvas.controller.multiFrameNumber = 1024;
+    canvas.controller.multiFrameNumber = 8;
     canvas.frameScale = [1.0, 1.0];
     renderer = new gloperate.debug.LabelRenderer();
     canvas.renderer = renderer;


### PR DESCRIPTION
* handles error messages/reasons more appropriately
* refines error handling of `texture2D.load`
* removes transform design from `fetchAsycn` - now use `.then`