### PR TITLE
WIP Word wrap: ellipsis

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "ts-node": "~7.0.1",
         "tslint": "~5.11.0",
         "typedoc": "~0.13.0",
-        "typescript": "~3.1.3",
+        "typescript": "~3.0.1",
         "webpack": "~4.20.2",
         "webpack-bundle-analyzer": "~3.0.3",
         "webpack-cli": "~3.1.2",

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -332,7 +332,7 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            /** Wrapped labels using Ellipse */
+            /** Wrapped labels using Ellipsis */
 
             const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
@@ -340,7 +340,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped2DLabel.wordWrap = true;
             wrapped2DLabel.maxLineWidth = 500;
-            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
 
 
             const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
@@ -349,7 +349,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped3DLabel.wordWrap = true;
             wrapped3DLabel.maxLineWidth = 1;
-            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -7,6 +7,7 @@ import { AccumulatePass } from '../accumulatepass';
 import { AntiAliasingKernel } from '../antialiasingkernel';
 import { BlitPass } from '../blitpass';
 import { Camera } from '../camera';
+import { Color } from '../color';
 import { Context } from '../context';
 import { DefaultFramebuffer } from '../defaultframebuffer';
 import { Framebuffer } from '../framebuffer';
@@ -19,6 +20,7 @@ import { Shader } from '../shader';
 import { Texture2D } from '../texture2d';
 
 import { FontFace } from '../text/fontface';
+import { Label } from '../text/label';
 import { LabelRenderPass } from '../text/labelrenderpass';
 import { Position2DLabel } from '../text/position2dlabel';
 import { Position3DLabel } from '../text/position3dlabel';
@@ -146,6 +148,7 @@ namespace debug {
             this._labelPass.initialize();
             this._labelPass.camera = this._camera;
             this._labelPass.target = this._intermediateFBO;
+            this._labelPass.color = new Color([1.0, 1.0, 1.0, 1.0]);
 
             FontFace.fromFile('./data/opensansr144.fnt', context).then((fontFace) => {
                 this._labelPass.fontFace = fontFace;
@@ -327,7 +330,28 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel];
+            /** Wrapped labels using Ellipse */
+
+            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped2DLabel.wordWrap = true;
+            wrapped2DLabel.maxLineWidth = 500;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+
+
+            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped3DLabel.wordWrap = true;
+            wrapped3DLabel.maxLineWidth = 1;
+            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped3DLabel.setPosition(-1, 0.1, 0);
+
+            this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
+                wrapped2DLabel, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -332,22 +332,20 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            /** Wrapped labels using Ellipsis */
 
-            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+            /** Wrapped labels, showcasing Ellipsis and NewLine */
+
+            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text: NewLine.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped2DLabel.wordWrap = true;
             wrapped2DLabel.maxLineWidth = 500;
-            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
-
-            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: Ellipsis.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel.wordWrap = true;
             wrapped3DLabel.maxLineWidth = 1;
             wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
             wrapped3DLabel.setPosition(-1, 0.1, 0);

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -19,11 +19,8 @@ export class Label {
     /** @see {@link text} */
     protected _text: Text;
 
-    /** @see {@link wordWrap} */
-    protected _wordWrap = false;
-
     /** @see {@link wordWrapper} */
-    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.NewLine;
+    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.None;
 
     /** @see {@link maxLineWidth} */
     protected _maxLineWidth = 0.0;
@@ -188,21 +185,6 @@ export class Label {
     }
 
     /**
-     * Whether or not words can be wrapped at the end of a line.
-     * @param wrap - `true` if word wrap is enabled, else `false`
-     */
-    set wordWrap(wrap: boolean) {
-        if (this._wordWrap === wrap) {
-            return;
-        }
-        this._altered.alter('typesetting');
-        this._wordWrap = wrap;
-    }
-    get wordWrap(): boolean {
-        return this._wordWrap;
-    }
-
-    /**
      * Which algorithm should be used when label.wordWrap = true and label exceeds the defined maximum line width, see
      * maxLineWidth();
      */
@@ -215,7 +197,7 @@ export class Label {
 
     /**
      * Maximum line width allowed for this label. The current label.fontSizeUnit is used as line width unit.
-     * The maximum line width is ignored if label.wordWrap==false.
+     * The maximum line width is ignored if label.wordWrapper==Label.WordWrapper.None
      */
     set maxLineWidth(maxLineWidth: number) {
         this._maxLineWidth = maxLineWidth;
@@ -225,8 +207,8 @@ export class Label {
     }
 
     /**
-     * Width of a single line (in px or w.r.t. font face scaling in world space respectively). The width of the line
-     * is not intended to be set explicitly, but implicitly via transformations/label placement in its subclass.
+     * Width of a single line (in typesetting space). The width of the line is not intended to be set explicitly, but
+     * implicitly via transformations/label placement in its subclass.
      */
     get lineWidth(): number {
         return this._lineWidth;
@@ -416,6 +398,7 @@ export class Label {
 export namespace Label {
 
     export enum WordWrapper {
+        None = 'none',
         NewLine = 'newLine',
         Ellipsis = 'ellipsis',
     }

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -17,10 +17,16 @@ import { Text } from './text';
 export class Label {
 
     /** @see {@link text} */
-    protected _text: Text | string;
+    protected _text: Text;
 
     /** @see {@link wordWrap} */
     protected _wordWrap = false;
+
+    /** @see {@link wordWrapper} */
+    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.NewLine;
+
+    /** @see {@link maxLineWidth} */
+    protected _maxLineWidth = 0.0;
 
     /** @see {@link alignment} */
     protected _alignment: Label.Alignment = Label.Alignment.Left;
@@ -91,9 +97,6 @@ export class Label {
      * @returns character at the specified index
      */
     charAt(index: number): string {
-        if (this._text instanceof Text) {
-            return this._text.text.charAt(index);
-        }
         return this._text.charAt(index);
     }
 
@@ -104,9 +107,6 @@ export class Label {
      * @returns - codepoint of the char at given index or NaN
      */
     charCodeAt(index: number): number {
-        if (this._text instanceof Text) {
-            return this._text.text.charCodeAt(index);
-        }
         return this._text.charCodeAt(index);
     }
 
@@ -162,11 +162,11 @@ export class Label {
     /**
      * Text that is to be rendered.
      */
-    set text(text: Text | string) {
+    set text(text: Text) {
         this._altered.alter('text');
         this._text = text;
     }
-    get text(): Text | string {
+    get text(): Text {
         return this._text;
     }
 
@@ -203,6 +203,36 @@ export class Label {
     }
 
     /**
+     * Which algorithm should be used when label.wordWrap = true and label exceeds the defined maximum line width, see
+     * maxLineWidth();
+     */
+    set wordWrapper(wordWrapper: Label.WordWrapper) {
+        this._wordWrapper = wordWrapper;
+    }
+    get wordWrapper(): Label.WordWrapper {
+        return this._wordWrapper;
+    }
+
+    /**
+     * Maximum line width allowed for this label. The current label.fontSizeUnit is used as line width unit.
+     * The maximum line width is ignored if label.wordWrap==false.
+     */
+    set maxLineWidth(maxLineWidth: number) {
+        this._maxLineWidth = maxLineWidth;
+    }
+    get maxLineWidth(): number {
+        return this._maxLineWidth;
+    }
+
+    /**
+     * Width of a single line (in px or w.r.t. font face scaling in world space respectively). The width of the line
+     * is not intended to be set explicitly, but implicitly via transformations/label placement in its subclass.
+     */
+    get lineWidth(): number {
+        return this._lineWidth;
+    }
+
+    /**
      * Horizontal text alignment for typesetting.
      */
     set alignment(alignment: Label.Alignment) {
@@ -230,13 +260,6 @@ export class Label {
         return this._lineAnchor;
     }
 
-    /**
-     * Width of a single line (in pt or w.r.t. font face scaling in world space respectively). The width of the line
-     * is not intended to be set explicitly, but implicitly via transformations/label placement.
-     */
-    get lineWidth(): number {
-        return this._lineWidth;
-    }
 
     /**
      * The currently used font size.
@@ -391,6 +414,11 @@ export class Label {
 }
 
 export namespace Label {
+
+    export enum WordWrapper {
+        NewLine = 'newLine',
+        Ellipse = 'ellipse',
+    }
 
     export enum Alignment {
         Left = 'left',

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -417,7 +417,7 @@ export namespace Label {
 
     export enum WordWrapper {
         NewLine = 'newLine',
-        Ellipse = 'ellipse',
+        Ellipsis = 'ellipsis',
     }
 
     export enum Alignment {
@@ -436,7 +436,7 @@ export namespace Label {
     }
 
     /**
-     * This unit is used for the font size.
+     * This unit is used for the font size and related calculations.
      */
     export enum SpaceUnit {
         /* abstract world unit */

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -84,10 +84,17 @@ export class Position2DLabel extends Label {
             angle = -angle;
         }
 
-        mat4.rotateZ(transform, transform, angle);
+        /** use the setter to trigger label.transform.altered */
+        this.transform = mat4.rotateZ(transform, transform, angle);
 
-        this.transform = transform;
-
+        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+            /** Note:
+             * this.fontSize uses this.fontSizeUnit,
+             * maxLineWidth uses this.fontSizeUnit,
+             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
+             */
+            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
+        }
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);
 

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -87,7 +87,7 @@ export class Position2DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.rotateZ(transform, transform, angle);
 
-        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+        if (this._maxLineWidth > 0.0) {
             /** Note:
              * this.fontSize uses this.fontSizeUnit,
              * maxLineWidth uses this.fontSizeUnit,

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -62,7 +62,17 @@ export class Position3DLabel extends Label {
             normal[0], normal[1], normal[2], 0,
             0.0, 0.0, 0.0, 1.0);
 
-        this.transform = mat4.mul(this.transform, transform, rotation);
+        /** use the setter to trigger label.transform.altered */
+        this.transform = mat4.mul(transform, transform, rotation);
+
+        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+            /** Note:
+             * this.fontSize uses this.fontSizeUnit,
+             * maxLineWidth uses this.fontSizeUnit,
+             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
+             */
+            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
+        }
 
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -65,7 +65,7 @@ export class Position3DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.mul(transform, transform, rotation);
 
-        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+        if (this._maxLineWidth > 0.0) {
             /** Note:
              * this.fontSize uses this.fontSizeUnit,
              * maxLineWidth uses this.fontSizeUnit,

--- a/source/text/text.ts
+++ b/source/text/text.ts
@@ -38,6 +38,26 @@ export class Text {
     }
 
     /**
+     * Returns the character at the specified index.
+     * @param index - The zero-based index of the desired character.
+     * @returns character at the specified index
+     */
+    charAt(index: number): string {
+        return this._text.charAt(index);
+    }
+
+    /**
+     * Returns the Unicode value (codepoint) of the character at the specified location.
+     * @param index - The zero-based index of the desired character. If there is no character at the specified index,
+     * NaN is returned.
+     * @returns - codepoint of the char at given index or NaN
+     */
+    charCodeAt(index: number): number {
+        return this._text.charCodeAt(index);
+    }
+
+
+    /**
      * Text that is to be rendered.
      */
     set text(text: string) {

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -23,7 +23,7 @@ export class Typesetter {
 
     /**
      * Returns if newline should be applied for next word (or next glyph if word exceeds the line width)
-     * @param label the label that has wordWrap enabled
+     * @param label the label that has a wordWrapper different from WordWrapper.None
      * @param pen horizontal and vertical position at which typesetting takes place/arrived.
      * @param glyph current glyph
      * @param index current index for char in this label
@@ -31,7 +31,8 @@ export class Typesetter {
      * @returns whether or not typesetting should go on a new line
      */
     protected static wordWrap(label: Label, pen: vec2, glyph: Glyph, index: number, safeForwardIndex: number): boolean {
-        assert(label.wordWrap, `expected wordWrap to be enabled for label, given ${label}`);
+        assert(label.wordWrapper !== Label.WordWrapper.None,
+            `expected a WordWrapper enabled for label, given ${label.wordWrapper}`);
         const lineWidth = label.lineWidth;
 
         const penForward = pen[0] + glyph.advance + (index > 0 ? label.kerningBefore(index) : 0.0);
@@ -266,13 +267,12 @@ export class Typesetter {
 
         let index = iBegin;
 
-        /* todo - omfg - refactor this */
         for (; index !== iEnd; ++index) {
             let glyph = label.fontFace!.glyph(label.charCodeAt(index));
 
             /* Handle line feeds as well as word wrap for next word (or next glyph if word exceeds the line width). */
 
-            const reachingMaxLineWidth = (label.wordWrap &&
+            const reachingMaxLineWidth = (label.wordWrapper !== Label.WordWrapper.None &&
                 Typesetter.wordWrap(label, pen, glyph, index, safeForwardIndex));
 
             const feedLine = label.lineFeedAt(index) ||

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -279,7 +279,7 @@ export class Typesetter {
                 (reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.NewLine);
 
             const elideRemainingGlyphs =
-                reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.Ellipse;
+                reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.Ellipsis;
 
             if (feedLine) {
                 /* Handle pen and extent w.r.t. non-depictable glyphs. */


### PR DESCRIPTION
A label can have a maximum line width. If the label exceeds this line width, the word wrapper mode decides wether the label goes on a next line (`newLine`) or wether the label gets abbreviated, using an `Ellipsis` (e.g., "This is too long" --> "This is t..")

The `wordWrap` property is removed from label, since its functionality is already covered by the `wordWrapper` property. (`wordWrap=false` is now `wordWrapper.None`). This removes ambiguity. This is a _breaking change_.