### PR TITLE
Word wrappers

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
         "ts-node": "~7.0.1",
         "tslint": "~5.11.0",
         "typedoc": "~0.13.0",
-        "typescript": "~3.1.3",
+        "typescript": "~3.0.1",
         "webpack": "~4.20.2",
         "webpack-bundle-analyzer": "~3.0.3",
         "webpack-cli": "~3.1.2",

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -332,7 +332,7 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            /** Wrapped labels using Ellipse */
+            /** Wrapped labels using Ellipsis */
 
             const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
@@ -340,7 +340,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped2DLabel.wordWrap = true;
             wrapped2DLabel.maxLineWidth = 500;
-            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
 
 
             const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
@@ -349,7 +349,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped3DLabel.wordWrap = true;
             wrapped3DLabel.maxLineWidth = 1;
-            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -342,11 +342,12 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped2DLabel.lineWidth = 500;
             wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
+            const a = 1; // 0.0668; // 0.03993;
             const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: EllipsisEnd.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel.lineWidth = 1;
+            wrapped3DLabel.lineWidth = a;
             wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
             wrapped3DLabel.setPosition(-1, 0.4, 0);
 
@@ -354,7 +355,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel3.lineWidth = 1;
+            wrapped3DLabel3.lineWidth = a;
             wrapped3DLabel3.wordWrapper = Label.WordWrapper.EllipsisMiddle;
             wrapped3DLabel3.setPosition(-1, 0.1, 0);
 
@@ -362,17 +363,12 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel2.lineWidth = 1;
+            wrapped3DLabel2.lineWidth = a;
             wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
-            const shouldNotNeedWrap = new Position3DLabel(new Text('Yepyepyepyepyepyepyepyepyepyepyepyepyepyepyepyep'));
-            shouldNotNeedWrap.lineWidth = 2;
-            shouldNotNeedWrap.wordWrapper = Label.WordWrapper.EllipsisMiddle;
-            shouldNotNeedWrap.setPosition(-1, 0.5, 0);
-
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
-                shouldNotNeedWrap, wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
+                wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -350,7 +350,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
-            const wrapped3DLabel2 = new Position3DLabel(new Text('This is a very long text: EllipsisEnd.\n\
+            const wrapped3DLabel2 = new Position3DLabel(new Text('This is a very long text: EllipsisBeginning.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
@@ -358,9 +358,16 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
+            const wrapped3DLabel3 = new Position3DLabel(new Text('This is a very long text: EllipsisMiddle.\n\
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped3DLabel3.maxLineWidth = 1;
+            wrapped3DLabel3.wordWrapper = Label.WordWrapper.EllipsisMiddle;
+            wrapped3DLabel3.setPosition(-1, 0.4, 0);
 
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
-                wrapped2DLabel, wrapped3DLabel2, wrapped3DLabel];
+                wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -342,12 +342,12 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped2DLabel.maxLineWidth = 500;
             wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
-            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: Ellipsis.\n\
+            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: EllipsisEnd.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped3DLabel.maxLineWidth = 1;
-            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
+            wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -366,8 +366,8 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
             const differentEllipsis = new Position2DLabel(new Text('EllipsisEllipsisEllipsisEllipsisEllipsisEllipsis'));
-            differentEllipsis.ellpsisChars = '~';
-            differentEllipsis.setPosition(-200, -200);
+            differentEllipsis.ellipsisChars = '~';
+            differentEllipsis.setPosition(-200, -150);
             differentEllipsis.lineWidth = 200;
             differentEllipsis.wordWrapper = Label.WordWrapper.EllipsisMiddle;
 

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -7,6 +7,7 @@ import { AccumulatePass } from '../accumulatepass';
 import { AntiAliasingKernel } from '../antialiasingkernel';
 import { BlitPass } from '../blitpass';
 import { Camera } from '../camera';
+import { Color } from '../color';
 import { Context } from '../context';
 import { DefaultFramebuffer } from '../defaultframebuffer';
 import { Framebuffer } from '../framebuffer';
@@ -19,6 +20,7 @@ import { Shader } from '../shader';
 import { Texture2D } from '../texture2d';
 
 import { FontFace } from '../text/fontface';
+import { Label } from '../text/label';
 import { LabelRenderPass } from '../text/labelrenderpass';
 import { Position2DLabel } from '../text/position2dlabel';
 import { Position3DLabel } from '../text/position3dlabel';
@@ -146,6 +148,7 @@ namespace debug {
             this._labelPass.initialize();
             this._labelPass.camera = this._camera;
             this._labelPass.target = this._intermediateFBO;
+            this._labelPass.color = new Color([1.0, 1.0, 1.0, 1.0]);
 
             FontFace.fromFile('./data/opensansr144.fnt', context).then((fontFace) => {
                 this._labelPass.fontFace = fontFace;
@@ -327,7 +330,28 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel];
+            /** Wrapped labels using Ellipse */
+
+            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped2DLabel.wordWrap = true;
+            wrapped2DLabel.maxLineWidth = 500;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+
+
+            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped3DLabel.wordWrap = true;
+            wrapped3DLabel.maxLineWidth = 1;
+            wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipse;
+            wrapped3DLabel.setPosition(-1, 0.1, 0);
+
+            this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
+                wrapped2DLabel, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -336,9 +336,7 @@ namespace debug {
             /** Wrapped labels, showcasing Ellipsis and NewLine */
 
             const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text: NewLine.\n\
-This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
-is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
- very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped2DLabel.lineWidth = 500;
             wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
@@ -367,8 +365,14 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
+            const differentEllipsis = new Position2DLabel(new Text('EllipsisEllipsisEllipsisEllipsisEllipsisEllipsis'));
+            differentEllipsis.ellpsisChars = '~';
+            differentEllipsis.setPosition(-200, -200);
+            differentEllipsis.lineWidth = 200;
+            differentEllipsis.wordWrapper = Label.WordWrapper.EllipsisMiddle;
+
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
-                wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
+                wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel, differentEllipsis];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -348,7 +348,15 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
             wrapped3DLabel.lineWidth = 1;
             wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
-            wrapped3DLabel.setPosition(-1, 0.1, 0);
+            wrapped3DLabel.setPosition(-1, 0.4, 0);
+
+            const wrapped3DLabel3 = new Position3DLabel(new Text('This is a very long text: EllipsisMiddle.\n\
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped3DLabel3.lineWidth = 1;
+            wrapped3DLabel3.wordWrapper = Label.WordWrapper.EllipsisMiddle;
+            wrapped3DLabel3.setPosition(-1, 0.1, 0);
 
             const wrapped3DLabel2 = new Position3DLabel(new Text('This is a very long text: EllipsisBeginning.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
@@ -358,16 +366,13 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
-            const wrapped3DLabel3 = new Position3DLabel(new Text('This is a very long text: EllipsisMiddle.\n\
-This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
-is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
- very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel3.lineWidth = 1;
-            wrapped3DLabel3.wordWrapper = Label.WordWrapper.EllipsisMiddle;
-            wrapped3DLabel3.setPosition(-1, 0.4, 0);
+            const shouldNotNeedWrap = new Position3DLabel(new Text('Yepyepyepyepyepyepyepyepyepyepyepyepyepyepyepyep'));
+            shouldNotNeedWrap.lineWidth = 2;
+            shouldNotNeedWrap.wordWrapper = Label.WordWrapper.EllipsisMiddle;
+            shouldNotNeedWrap.setPosition(-1, 0.5, 0);
 
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
-                wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
+                shouldNotNeedWrap, wrapped2DLabel, wrapped3DLabel3, wrapped3DLabel2, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -350,8 +350,17 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
             wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
+            const wrapped3DLabel2 = new Position3DLabel(new Text('This is a very long text: EllipsisEnd.\n\
+This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
+is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
+ very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
+            wrapped3DLabel2.maxLineWidth = 1;
+            wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
+            wrapped3DLabel2.setPosition(-1, -0.2, 0);
+
+
             this._labelPass.labels = [pos3Dlabel, shadowPos3Dlabel, anotherPos3Dlabel, pos2Dlabel,
-                wrapped2DLabel, wrapped3DLabel];
+                wrapped2DLabel, wrapped3DLabel2, wrapped3DLabel];
         }
     }
 }

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -339,14 +339,14 @@ namespace debug {
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped2DLabel.maxLineWidth = 500;
+            wrapped2DLabel.lineWidth = 500;
             wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
             const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: EllipsisEnd.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel.maxLineWidth = 1;
+            wrapped3DLabel.lineWidth = 1;
             wrapped3DLabel.wordWrapper = Label.WordWrapper.EllipsisEnd;
             wrapped3DLabel.setPosition(-1, 0.1, 0);
 
@@ -354,7 +354,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel2.maxLineWidth = 1;
+            wrapped3DLabel2.lineWidth = 1;
             wrapped3DLabel2.wordWrapper = Label.WordWrapper.EllipsisBeginning;
             wrapped3DLabel2.setPosition(-1, -0.2, 0);
 
@@ -362,7 +362,7 @@ is a very long text. Too long, to be precise. This is a very long text. Too long
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel3.maxLineWidth = 1;
+            wrapped3DLabel3.lineWidth = 1;
             wrapped3DLabel3.wordWrapper = Label.WordWrapper.EllipsisMiddle;
             wrapped3DLabel3.setPosition(-1, 0.4, 0);
 

--- a/source/debug/labelrenderer.ts
+++ b/source/debug/labelrenderer.ts
@@ -332,22 +332,20 @@ namespace debug {
             pos2Dlabel.setPosition(-100, 0);
             pos2Dlabel.setDirection(0.5, -0.5);
 
-            /** Wrapped labels using Ellipsis */
 
-            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+            /** Wrapped labels, showcasing Ellipsis and NewLine */
+
+            const wrapped2DLabel = new Position2DLabel(new Text('This is a very long text: NewLine.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped2DLabel.wordWrap = true;
             wrapped2DLabel.maxLineWidth = 500;
-            wrapped2DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
+            wrapped2DLabel.wordWrapper = Label.WordWrapper.NewLine;
 
-
-            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text.\nToo long, to be precise. \
+            const wrapped3DLabel = new Position3DLabel(new Text('This is a very long text: Ellipsis.\n\
 This is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This \
 is a very long text. Too long, to be precise. This is a very long text. Too long, to be precise. This is a\
  very long text. Too long, to be precise. This is a very long text. Too long, to be precise.'));
-            wrapped3DLabel.wordWrap = true;
             wrapped3DLabel.maxLineWidth = 1;
             wrapped3DLabel.wordWrapper = Label.WordWrapper.Ellipsis;
             wrapped3DLabel.setPosition(-1, 0.1, 0);

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -19,11 +19,8 @@ export class Label {
     /** @see {@link text} */
     protected _text: Text;
 
-    /** @see {@link wordWrap} */
-    protected _wordWrap = false;
-
     /** @see {@link wordWrapper} */
-    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.NewLine;
+    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.None;
 
     /** @see {@link maxLineWidth} */
     protected _maxLineWidth = 0.0;
@@ -188,21 +185,6 @@ export class Label {
     }
 
     /**
-     * Whether or not words can be wrapped at the end of a line.
-     * @param wrap - `true` if word wrap is enabled, else `false`
-     */
-    set wordWrap(wrap: boolean) {
-        if (this._wordWrap === wrap) {
-            return;
-        }
-        this._altered.alter('typesetting');
-        this._wordWrap = wrap;
-    }
-    get wordWrap(): boolean {
-        return this._wordWrap;
-    }
-
-    /**
      * Which algorithm should be used when label.wordWrap = true and label exceeds the defined maximum line width, see
      * maxLineWidth();
      */
@@ -215,7 +197,7 @@ export class Label {
 
     /**
      * Maximum line width allowed for this label. The current label.fontSizeUnit is used as line width unit.
-     * The maximum line width is ignored if label.wordWrap==false.
+     * The maximum line width is ignored if label.wordWrapper==Label.WordWrapper.None
      */
     set maxLineWidth(maxLineWidth: number) {
         this._maxLineWidth = maxLineWidth;
@@ -225,8 +207,8 @@ export class Label {
     }
 
     /**
-     * Width of a single line (in px or w.r.t. font face scaling in world space respectively). The width of the line
-     * is not intended to be set explicitly, but implicitly via transformations/label placement in its subclass.
+     * Width of a single line (in typesetting space). The width of the line is not intended to be set explicitly, but
+     * implicitly via transformations/label placement in its subclass.
      */
     get lineWidth(): number {
         return this._lineWidth;
@@ -416,6 +398,7 @@ export class Label {
 export namespace Label {
 
     export enum WordWrapper {
+        None = 'none',
         NewLine = 'newLine',
         Ellipsis = 'ellipsis',
     }

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -17,10 +17,16 @@ import { Text } from './text';
 export class Label {
 
     /** @see {@link text} */
-    protected _text: Text | string;
+    protected _text: Text;
 
     /** @see {@link wordWrap} */
     protected _wordWrap = false;
+
+    /** @see {@link wordWrapper} */
+    protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.NewLine;
+
+    /** @see {@link maxLineWidth} */
+    protected _maxLineWidth = 0.0;
 
     /** @see {@link alignment} */
     protected _alignment: Label.Alignment = Label.Alignment.Left;
@@ -91,9 +97,6 @@ export class Label {
      * @returns character at the specified index
      */
     charAt(index: number): string {
-        if (this._text instanceof Text) {
-            return this._text.text.charAt(index);
-        }
         return this._text.charAt(index);
     }
 
@@ -104,9 +107,6 @@ export class Label {
      * @returns - codepoint of the char at given index or NaN
      */
     charCodeAt(index: number): number {
-        if (this._text instanceof Text) {
-            return this._text.text.charCodeAt(index);
-        }
         return this._text.charCodeAt(index);
     }
 
@@ -162,11 +162,11 @@ export class Label {
     /**
      * Text that is to be rendered.
      */
-    set text(text: Text | string) {
+    set text(text: Text) {
         this._altered.alter('text');
         this._text = text;
     }
-    get text(): Text | string {
+    get text(): Text {
         return this._text;
     }
 
@@ -203,6 +203,36 @@ export class Label {
     }
 
     /**
+     * Which algorithm should be used when label.wordWrap = true and label exceeds the defined maximum line width, see
+     * maxLineWidth();
+     */
+    set wordWrapper(wordWrapper: Label.WordWrapper) {
+        this._wordWrapper = wordWrapper;
+    }
+    get wordWrapper(): Label.WordWrapper {
+        return this._wordWrapper;
+    }
+
+    /**
+     * Maximum line width allowed for this label. The current label.fontSizeUnit is used as line width unit.
+     * The maximum line width is ignored if label.wordWrap==false.
+     */
+    set maxLineWidth(maxLineWidth: number) {
+        this._maxLineWidth = maxLineWidth;
+    }
+    get maxLineWidth(): number {
+        return this._maxLineWidth;
+    }
+
+    /**
+     * Width of a single line (in px or w.r.t. font face scaling in world space respectively). The width of the line
+     * is not intended to be set explicitly, but implicitly via transformations/label placement in its subclass.
+     */
+    get lineWidth(): number {
+        return this._lineWidth;
+    }
+
+    /**
      * Horizontal text alignment for typesetting.
      */
     set alignment(alignment: Label.Alignment) {
@@ -230,13 +260,6 @@ export class Label {
         return this._lineAnchor;
     }
 
-    /**
-     * Width of a single line (in pt or w.r.t. font face scaling in world space respectively). The width of the line
-     * is not intended to be set explicitly, but implicitly via transformations/label placement.
-     */
-    get lineWidth(): number {
-        return this._lineWidth;
-    }
 
     /**
      * The currently used font size.
@@ -391,6 +414,11 @@ export class Label {
 }
 
 export namespace Label {
+
+    export enum WordWrapper {
+        NewLine = 'newLine',
+        Ellipse = 'ellipse',
+    }
 
     export enum Alignment {
         Left = 'left',

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -22,8 +22,8 @@ export class Label {
     /** @see {@link wordWrapper} */
     protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.None;
 
-    /** @see {@link ellpsisChars} */
-    protected _ellpsisChars = '...';
+    /** @see {@link ellipsisChars} */
+    protected _ellipsisChars = '...';
 
     /** @see {@link alignment} */
     protected _alignment: Label.Alignment = Label.Alignment.Left;
@@ -198,11 +198,11 @@ export class Label {
      * Set the characters that should be used as an ellipsis. Only takes effect when label.wordWrapper is one
      * of the ellipsis wrappers (e.g., Label.WordWrapper.EllipsisMiddle).
      */
-    set ellpsisChars(ellpsisChars: string) {
-        this._ellpsisChars = ellpsisChars;
+    set ellipsisChars(ellipsisChars: string) {
+        this._ellipsisChars = ellipsisChars;
     }
-    get ellpsisChars(): string {
-        return this._ellpsisChars;
+    get ellipsisChars(): string {
+        return this._ellipsisChars;
     }
 
     /**

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -417,7 +417,7 @@ export namespace Label {
 
     export enum WordWrapper {
         NewLine = 'newLine',
-        Ellipse = 'ellipse',
+        Ellipsis = 'ellipsis',
     }
 
     export enum Alignment {
@@ -436,7 +436,7 @@ export namespace Label {
     }
 
     /**
-     * This unit is used for the font size.
+     * This unit is used for the font size and related calculations.
      */
     export enum SpaceUnit {
         /* abstract world unit */

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -22,6 +22,9 @@ export class Label {
     /** @see {@link wordWrapper} */
     protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.None;
 
+    /** @see {@link ellpsisChars} */
+    protected _ellpsisChars = '...';
+
     /** @see {@link alignment} */
     protected _alignment: Label.Alignment = Label.Alignment.Left;
 
@@ -189,6 +192,17 @@ export class Label {
     }
     get wordWrapper(): Label.WordWrapper {
         return this._wordWrapper;
+    }
+
+    /**
+     * Set the characters that should be used as an ellipsis. Only takes effect when label.wordWrapper is one
+     * of the ellipsis wrappers (e.g., Label.WordWrapper.EllipsisMiddle).
+     */
+    set ellpsisChars(ellpsisChars: string) {
+        this._ellpsisChars = ellpsisChars;
+    }
+    get ellpsisChars(): string {
+        return this._ellpsisChars;
     }
 
     /**

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -81,7 +81,7 @@ export class Label {
     }
 
     /**
-     * Creates an Array of glyph vertices with given length, ready to be used in the Typesetter.
+     * Creates an Array of glyph vertices, ready to be used in the Typesetter.
      */
     protected prepareVertexStorage(): GlyphVertices {
         const vertices = new GlyphVertices(this.length);
@@ -400,7 +400,9 @@ export namespace Label {
     export enum WordWrapper {
         None = 'none',
         NewLine = 'newLine',
-        Ellipsis = 'ellipsis',
+        EllipsisEnd = 'ellipsisEnd',
+        EllipsisMiddle = 'ellipsisMiddle',
+        EllipsisBeginning = 'ellipsisBeginning',
     }
 
     export enum Alignment {

--- a/source/text/label.ts
+++ b/source/text/label.ts
@@ -22,9 +22,6 @@ export class Label {
     /** @see {@link wordWrapper} */
     protected _wordWrapper: Label.WordWrapper = Label.WordWrapper.None;
 
-    /** @see {@link maxLineWidth} */
-    protected _maxLineWidth = 0.0;
-
     /** @see {@link alignment} */
     protected _alignment: Label.Alignment = Label.Alignment.Left;
 
@@ -185,8 +182,7 @@ export class Label {
     }
 
     /**
-     * Which algorithm should be used when label.wordWrap = true and label exceeds the defined maximum line width, see
-     * maxLineWidth();
+     * Set the algorithm that should be used when the label exceeds the defined line width, see lineWidth()
      */
     set wordWrapper(wordWrapper: Label.WordWrapper) {
         this._wordWrapper = wordWrapper;
@@ -196,22 +192,22 @@ export class Label {
     }
 
     /**
-     * Maximum line width allowed for this label. The current label.fontSizeUnit is used as line width unit.
-     * The maximum line width is ignored if label.wordWrapper==Label.WordWrapper.None
+     * The (maximum) line width allowed for this label. The current label.fontSizeUnit is used as line width unit. It
+     * is ignored if label.wordWrapper==Label.WordWrapper.None
      */
-    set maxLineWidth(maxLineWidth: number) {
-        this._maxLineWidth = maxLineWidth;
-    }
-    get maxLineWidth(): number {
-        return this._maxLineWidth;
+    set lineWidth(lineWidth: number) {
+        this._lineWidth = lineWidth;
     }
 
     /**
-     * Width of a single line (in typesetting space). The width of the line is not intended to be set explicitly, but
-     * implicitly via transformations/label placement in its subclass.
+     * Width of a single line in typesetting space (the unit used while Typesetting, i.e., the unit as the fontFace's
+     * glyph texture atlas). Since the fontFace needs to be defined in order to typeset, we assume here that the label
+     * has a defined fontFace.
      */
     get lineWidth(): number {
-        return this._lineWidth;
+        /* this.fontSize and lineWidth use the same unit (i.e., this.fontSizeUnit),
+         * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas */
+        return this._lineWidth * this._fontFace!.size / this.fontSize;
     }
 
     /**

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -84,10 +84,17 @@ export class Position2DLabel extends Label {
             angle = -angle;
         }
 
-        mat4.rotateZ(transform, transform, angle);
+        /** use the setter to trigger label.transform.altered */
+        this.transform = mat4.rotateZ(transform, transform, angle);
 
-        this.transform = transform;
-
+        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+            /** Note:
+             * this.fontSize uses this.fontSizeUnit,
+             * maxLineWidth uses this.fontSizeUnit,
+             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
+             */
+            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
+        }
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);
 

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -87,7 +87,7 @@ export class Position2DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.rotateZ(transform, transform, angle);
 
-        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+        if (this._maxLineWidth > 0.0) {
             /** Note:
              * this.fontSize uses this.fontSizeUnit,
              * maxLineWidth uses this.fontSizeUnit,

--- a/source/text/position2dlabel.ts
+++ b/source/text/position2dlabel.ts
@@ -87,14 +87,6 @@ export class Position2DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.rotateZ(transform, transform, angle);
 
-        if (this._maxLineWidth > 0.0) {
-            /** Note:
-             * this.fontSize uses this.fontSizeUnit,
-             * maxLineWidth uses this.fontSizeUnit,
-             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
-             */
-            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
-        }
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);
 

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -65,15 +65,6 @@ export class Position3DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.mul(transform, transform, rotation);
 
-        if (this._maxLineWidth > 0.0) {
-            /** Note:
-             * this.fontSize uses this.fontSizeUnit,
-             * maxLineWidth uses this.fontSizeUnit,
-             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
-             */
-            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
-        }
-
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);
 

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -62,7 +62,17 @@ export class Position3DLabel extends Label {
             normal[0], normal[1], normal[2], 0,
             0.0, 0.0, 0.0, 1.0);
 
-        this.transform = mat4.mul(this.transform, transform, rotation);
+        /** use the setter to trigger label.transform.altered */
+        this.transform = mat4.mul(transform, transform, rotation);
+
+        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+            /** Note:
+             * this.fontSize uses this.fontSizeUnit,
+             * maxLineWidth uses this.fontSizeUnit,
+             * this._lineWidth is expected to be in the same unit as the fontFace's glyph texture atlas
+             */
+            this._lineWidth = this._maxLineWidth * this._fontFace!.size / this.fontSize;
+        }
 
         const vertices = this.prepareVertexStorage();
         Typesetter.typeset(this, vertices, 0);

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -50,7 +50,7 @@ export class Position3DLabel extends Label {
         const transform = mat4.create();
         const normal = vec3.create();
 
-        /* apply user transformations (position, direction) */
+        /* Apply user transformations (position, direction). */
 
         mat4.translate(transform, mat4.create(),
             vec3.fromValues(this._position[0], this._position[1], this._position[2]));
@@ -62,7 +62,7 @@ export class Position3DLabel extends Label {
             normal[0], normal[1], normal[2], 0,
             0.0, 0.0, 0.0, 1.0);
 
-        /** use the setter to trigger label.transform.altered */
+        /* Use the setter to trigger label.transform.altered. */
         this.transform = mat4.mul(transform, transform, rotation);
 
         const vertices = this.prepareVertexStorage();

--- a/source/text/position3dlabel.ts
+++ b/source/text/position3dlabel.ts
@@ -65,7 +65,7 @@ export class Position3DLabel extends Label {
         /** use the setter to trigger label.transform.altered */
         this.transform = mat4.mul(transform, transform, rotation);
 
-        if (this._maxLineWidth > 0.0 || this.wordWrap === true) {
+        if (this._maxLineWidth > 0.0) {
             /** Note:
              * this.fontSize uses this.fontSizeUnit,
              * maxLineWidth uses this.fontSizeUnit,

--- a/source/text/text.ts
+++ b/source/text/text.ts
@@ -48,9 +48,8 @@ export class Text {
 
     /**
      * Returns the Unicode value (codepoint) of the character at the specified location.
-     * @param index - The zero-based index of the desired character. If there is no character at the specified index,
-     * NaN is returned.
-     * @returns - codepoint of the char at given index or NaN
+     * @param index - The zero-based index of the desired character.
+     * @returns - Codepoint of the character at given index or NaN, if no character exists at index.
      */
     charCodeAt(index: number): number {
         return this._text.charCodeAt(index);

--- a/source/text/text.ts
+++ b/source/text/text.ts
@@ -38,6 +38,26 @@ export class Text {
     }
 
     /**
+     * Returns the character at the specified index.
+     * @param index - The zero-based index of the desired character.
+     * @returns character at the specified index
+     */
+    charAt(index: number): string {
+        return this._text.charAt(index);
+    }
+
+    /**
+     * Returns the Unicode value (codepoint) of the character at the specified location.
+     * @param index - The zero-based index of the desired character. If there is no character at the specified index,
+     * NaN is returned.
+     * @returns - codepoint of the char at given index or NaN
+     */
+    charCodeAt(index: number): number {
+        return this._text.charCodeAt(index);
+    }
+
+
+    /**
      * Text that is to be rendered.
      */
     set text(text: string) {

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -30,13 +30,12 @@ export class Typesetter {
      * @param safeForwardIndex used to reduce the number of wordwrap forward passes
      * @returns whether or not typesetting should go on a new line
      */
-    protected static wordWrap(label: Label, pen: vec2, glyph: Glyph, index: number, safeForwardIndex: Array<number>):
-        boolean {
-        // assert(label.wordWrapper !== Label.WordWrapper.None,
-        //     `expected a WordWrapper enabled for label, given ${label.wordWrapper}`);
-        const lineWidth = label.lineWidth;
+    protected static wordWrap(label: Label, pen: vec2, glyph: Glyph, index: number, 
+        safeForwardIndex: Array<number>): boolean {
 
+        const lineWidth = label.lineWidth;
         const penForward = pen[0] + glyph.advance + (index > 0 ? label.kerningBefore(index) : 0.0);
+
         if (glyph.depictable() && penForward > lineWidth && (glyph.advance <= lineWidth || pen[0] > 0.0)) {
             return true;
         }

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -313,14 +313,14 @@ export class Typesetter {
 
                 const goalWidth = label.lineWidth - ellipsisWidth;
                 const sum = (accumulator: number, currentValue: number) => accumulator + currentValue;
-                let width = advancesPerGlyph.reduce(sum);
+                let width = advancesPerGlyph.reduce(sum, 0);
 
                 while (width > goalWidth) {
                     index = Math.floor(advancesPerGlyph.length / 2);
                     advancesPerGlyph.splice(index, 1);
                     newText = newText.slice(0, index) + newText.slice(index + 1);
 
-                    width = advancesPerGlyph.reduce(sum);
+                    width = advancesPerGlyph.reduce(sum, 0);
 
                     if (advancesPerGlyph.length < 1 || width === 0) {
                         index = 0;
@@ -399,7 +399,7 @@ export class Typesetter {
                  * @todo make it undoable? e.g., label.originalText and label.currentText ?
                  */
                 const newText = label.text;
-                newText.text = newText.text.slice(0, index - 1);
+                newText.text = newText.text.slice(0, index);
                 newText.text += this.ELLIPSIS_CHARS;
 
                 label.text = newText;
@@ -432,9 +432,8 @@ export class Typesetter {
         const iBegin = 0;
         const iEnd: number = label.length;
 
-        /* Index used to reduce the number of wordwrap forward passes. */
-        /* tslint:disable-next-line:prefer-const */
-        let safeForwardIndex = [iBegin];
+        /* Index used to reduce the number of wordwrap forward passes, wrapped in an Array for pass-by-reference */
+        const safeForwardIndex = [iBegin];
         let feedVertexIndex: number = vertexIndex;
 
         let index = iBegin;
@@ -463,13 +462,13 @@ export class Typesetter {
                 pen[0] += label.kerningBefore(index);
             }
 
-            advancesPerGlyph.push(pen[0] - width);
-            width = pen[0];
-
             /* Add and configure data for rendering the current character/glyph of the label. */
             Typesetter.transformGlyph(label.fontFace!, pen, glyph, glyphs ? glyphs.vertices[vertexIndex++] : undefined);
 
             pen[0] += glyph.advance;
+
+            advancesPerGlyph.push(pen[0] - width);
+            width = pen[0];
         }
 
         return [iBegin, iEnd, index, vertexIndex, feedVertexIndex];

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -21,9 +21,6 @@ export class Typesetter {
 
     protected static readonly DELIMITERS: string = '\x0A ,.-/()[]<>';
 
-    /** @todo should a Label define its ellipsis characters? */
-    protected static readonly ELLIPSIS_CHARS: string = '...';
-
     /**
      * Returns if newline should be applied for next word (or next glyph if word exceeds the line width)
      * @param label the label that has a wordWrapper different from WordWrapper.None
@@ -277,13 +274,13 @@ export class Typesetter {
          */
         let ellipsisWidth = 0;
 
-        for (let j = 0; j < this.ELLIPSIS_CHARS.length; j++) {
-            const glyph = label.fontFace!.glyph(this.ELLIPSIS_CHARS.charCodeAt(j));
+        for (let j = 0; j < label.ellpsisChars.length; j++) {
+            const glyph = label.fontFace!.glyph(label.ellpsisChars.charCodeAt(j));
 
             let kerning = 0;
-            if (j + 1 < this.ELLIPSIS_CHARS.length) {
+            if (j + 1 < label.ellpsisChars.length) {
                 kerning = label.fontFace!.kerning(
-                    this.ELLIPSIS_CHARS.charCodeAt(j), this.ELLIPSIS_CHARS.charCodeAt(j + 1));
+                    label.ellpsisChars.charCodeAt(j), label.ellpsisChars.charCodeAt(j + 1));
             }
 
             ellipsisWidth += glyph.advance + kerning;
@@ -326,7 +323,7 @@ export class Typesetter {
                 /** Update the label's text. We cannot undo this.
                  * @todo make it undoable? e.g., label.originalText and label.currentText ?
                  */
-                newText = newText.slice(0, index) + this.ELLIPSIS_CHARS + newText.slice(index + 1);
+                newText = newText.slice(0, index) + label.ellpsisChars + newText.slice(index + 1);
                 label.text.text = newText;
 
                 labelNeedsReTypeset = true;
@@ -360,7 +357,7 @@ export class Typesetter {
                  */
                 const newText = label.text;
                 newText.text = newText.text.slice(index + 1);
-                newText.text = this.ELLIPSIS_CHARS + newText.text;
+                newText.text = label.ellpsisChars + newText.text;
                 label.text = newText;
 
                 labelNeedsReTypeset = true;
@@ -395,7 +392,7 @@ export class Typesetter {
                  */
                 const newText = label.text;
                 newText.text = newText.text.slice(0, index);
-                newText.text += this.ELLIPSIS_CHARS;
+                newText.text += label.ellpsisChars;
 
                 label.text = newText;
 

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -323,7 +323,7 @@ export class Typesetter {
                 /** Update the label's text. We cannot undo this.
                  * @todo make it undoable? e.g., label.originalText and label.currentText ?
                  */
-                newText = newText.slice(0, index) + label.ellpsisChars + newText.slice(index + 1);
+                newText = newText.slice(0, index + 1) + label.ellpsisChars + newText.slice(index + 1);
                 label.text.text = newText;
 
                 labelNeedsReTypeset = true;

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -23,7 +23,7 @@ export class Typesetter {
 
     /**
      * Returns if newline should be applied for next word (or next glyph if word exceeds the line width)
-     * @param label the label that has wordWrap enabled
+     * @param label the label that has a wordWrapper different from WordWrapper.None
      * @param pen horizontal and vertical position at which typesetting takes place/arrived.
      * @param glyph current glyph
      * @param index current index for char in this label
@@ -31,7 +31,8 @@ export class Typesetter {
      * @returns whether or not typesetting should go on a new line
      */
     protected static wordWrap(label: Label, pen: vec2, glyph: Glyph, index: number, safeForwardIndex: number): boolean {
-        assert(label.wordWrap, `expected wordWrap to be enabled for label, given ${label}`);
+        assert(label.wordWrapper !== Label.WordWrapper.None,
+            `expected a WordWrapper enabled for label, given ${label.wordWrapper}`);
         const lineWidth = label.lineWidth;
 
         const penForward = pen[0] + glyph.advance + (index > 0 ? label.kerningBefore(index) : 0.0);
@@ -266,13 +267,12 @@ export class Typesetter {
 
         let index = iBegin;
 
-        /* todo - omfg - refactor this */
         for (; index !== iEnd; ++index) {
             let glyph = label.fontFace!.glyph(label.charCodeAt(index));
 
             /* Handle line feeds as well as word wrap for next word (or next glyph if word exceeds the line width). */
 
-            const reachingMaxLineWidth = (label.wordWrap &&
+            const reachingMaxLineWidth = (label.wordWrapper !== Label.WordWrapper.None &&
                 Typesetter.wordWrap(label, pen, glyph, index, safeForwardIndex));
 
             const feedLine = label.lineFeedAt(index) ||

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -279,7 +279,7 @@ export class Typesetter {
                 (reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.NewLine);
 
             const elideRemainingGlyphs =
-                reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.Ellipse;
+                reachingMaxLineWidth && label.wordWrapper === Label.WordWrapper.Ellipsis;
 
             if (feedLine) {
                 /* Handle pen and extent w.r.t. non-depictable glyphs. */

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -274,13 +274,13 @@ export class Typesetter {
          */
         let ellipsisWidth = 0;
 
-        for (let j = 0; j < label.ellpsisChars.length; j++) {
-            const glyph = label.fontFace!.glyph(label.ellpsisChars.charCodeAt(j));
+        for (let j = 0; j < label.ellipsisChars.length; j++) {
+            const glyph = label.fontFace!.glyph(label.ellipsisChars.charCodeAt(j));
 
             let kerning = 0;
-            if (j + 1 < label.ellpsisChars.length) {
+            if (j + 1 < label.ellipsisChars.length) {
                 kerning = label.fontFace!.kerning(
-                    label.ellpsisChars.charCodeAt(j), label.ellpsisChars.charCodeAt(j + 1));
+                    label.ellipsisChars.charCodeAt(j), label.ellipsisChars.charCodeAt(j + 1));
             }
 
             ellipsisWidth += glyph.advance + kerning;
@@ -323,7 +323,7 @@ export class Typesetter {
                 /** Update the label's text. We cannot undo this.
                  * @todo make it undoable? e.g., label.originalText and label.currentText ?
                  */
-                newText = newText.slice(0, index + 1) + label.ellpsisChars + newText.slice(index + 1);
+                newText = newText.slice(0, index + 1) + label.ellipsisChars + newText.slice(index + 1);
                 label.text.text = newText;
 
                 labelNeedsReTypeset = true;
@@ -357,7 +357,7 @@ export class Typesetter {
                  */
                 const newText = label.text;
                 newText.text = newText.text.slice(index + 1);
-                newText.text = label.ellpsisChars + newText.text;
+                newText.text = label.ellipsisChars + newText.text;
                 label.text = newText;
 
                 labelNeedsReTypeset = true;
@@ -392,7 +392,7 @@ export class Typesetter {
                  */
                 const newText = label.text;
                 newText.text = newText.text.slice(0, index);
-                newText.text += label.ellpsisChars;
+                newText.text += label.ellipsisChars;
 
                 label.text = newText;
 

--- a/source/text/typesetter.ts
+++ b/source/text/typesetter.ts
@@ -448,9 +448,6 @@ export class Typesetter {
                 (label.wordWrapper === Label.WordWrapper.NewLine
                     && Typesetter.wordWrap(label, pen, glyph, index, safeForwardIndex));
 
-            /** @todo use this function for WordWrapper.NewLine */
-            // console.log(safeForwardIndex[0], Typesetter.wordWrap(label, pen, glyph, index, safeForwardIndex));
-
             if (feedLine) {
                 /* Handle pen and extent w.r.t. non-depictable glyphs. */
                 Typesetter.backward(label, index - 1, iBegin, pen, extent);
@@ -504,12 +501,6 @@ export class Typesetter {
 
         /* Handle word wrap if label exceeds the maximum line width */
         if (label.lineWidth < pen[0]) {
-            if (index !== advancesPerGlyph.length || vertexIndex !== index || vertexIndex !== advancesPerGlyph.length) {
-                /** all three of them should be equal
-                 * @todo debug; remove this when in PR!
-                 */
-                console.warn(index, advancesPerGlyph.length, vertexIndex);
-            }
 
             const typesetAgain = this.applyWordWrapperEllipsis(label, advancesPerGlyph);
 


### PR DESCRIPTION
A label can have a maximum line width (`label.lineWidth`). If the label exceeds this line width, the word wrapper mode decides whether the label goes on a next line (`newLine`) or wether the label gets abbreviated, using an `Ellipsis` (e.g., "This is too long" --> "This is t..")

The `wordWrap` property is removed from label, since its functionality is already covered by the `wordWrapper` property. (`wordWrap=false` is now `wordWrapper.None`). This removes ambiguity. This is a _breaking change_.