### PR TITLE
Chrome: ID buffer is not cleared

### DIFF
--- a/source/framebuffer.ts
+++ b/source/framebuffer.ts
@@ -289,6 +289,12 @@ export class Framebuffer extends AbstractObject<WebGLFramebuffer> implements Bin
             gl.clear(gl.STENCIL_BUFFER_BIT);
         }
 
+        /**
+         * Unfortunately, the id buffer is not cleared in Chrome when this line is missing.
+         * @todo This fixed the Chrome-issue, but does it break other things?
+         */
+        gl.clear(mask);
+
         if (unbind) {
             this.unbind();
         }

--- a/source/framebuffer.ts
+++ b/source/framebuffer.ts
@@ -262,6 +262,11 @@ export class Framebuffer extends AbstractObject<WebGLFramebuffer> implements Bin
             for (const drawBuffer of colorClearQueue ? colorClearQueue : this._colorClearQueue) {
                 gl.clearBufferfv(gl.COLOR, drawBuffer, this._clearColors[drawBuffer]);
             }
+            /**
+             * Unfortunately, the above code doesn't work in Chrome (symptome: ID buffer is not cleared), so
+             * fallback to this line.
+             */
+            gl.clear(gl.COLOR_BUFFER_BIT);
         }
 
         if (clearDepth && clearStencil) {
@@ -288,12 +293,6 @@ export class Framebuffer extends AbstractObject<WebGLFramebuffer> implements Bin
             gl.clearStencil(this._clearStencil);
             gl.clear(gl.STENCIL_BUFFER_BIT);
         }
-
-        /**
-         * Unfortunately, the id buffer is not cleared in Chrome when this line is missing.
-         * @todo This fixed the Chrome-issue, but does it break other things?
-         */
-        gl.clear(mask);
 
         if (unbind) {
             this.unbind();


### PR DESCRIPTION
When Using Chrome, the ID-Buffer is not cleared (this issue appeared a few days ago, I cannot really pin it.*)
![grafik](https://user-images.githubusercontent.com/5690856/49585249-25219500-f95e-11e8-9d58-e98ffd14b3bf.png)

This affects functionality based on ID buffer, e.g. select on hovering.

This only happened on Chrome with webgl2 (more precisely, when `Framebuffer.es3Clear()` is used instead of `Framebuffer.es2Clear()` on Chrome.)

### This one-line-fix seems to fix this, but I am not sure if:

1. this might break other functionalities
2. this is a performance-issue, since it clears *everything*, altough specific buffers where cleared before
3. this line should only be executed when Chrome is detected, but I could not find future-proof browser detection.

Help is really much appreciated!


_____
\* It broke somewhere between 8584829b7790c9ede4c9360d35d24295c90e0475 and 1cf81b45f125e8ae28e237e58310b8af3bbc2704
