### PR TITLE
fix: don't uninitialize twice

### DIFF
--- a/source/geometry.ts
+++ b/source/geometry.ts
@@ -84,9 +84,6 @@ export abstract class Geometry extends Initializable implements Bindable {
     uninitialize(): void {
         this._vertexArray.uninitialize();
         this._buffers.forEach((buffer) => buffer.uninitialize());
-        for (const buffer of this._buffers) {
-            buffer.uninitialize();
-        }
     }
 
 


### PR DESCRIPTION
I decided to keep the `forEach`-loop and delete the for-of-loop. I hope this is okay.

Using webgl-operate as a lib, one might dispose the canvas --> uninitialize LabelRenderPass --> uninitialize LabelGeometry --> uninitializes Buffers TWICE, so the error is handled as a "dispose canvas error".

