### PR TITLE
don't initialize canvas size with 1 but with 0

### DIFF
--- a/source/canvas.ts
+++ b/source/canvas.ts
@@ -78,8 +78,11 @@ export class Canvas extends Resizable {
     /**
      * @see {@link size}
      * This property can be observed, e.g., `aCanvas.sizeObservable.subscribe()`.
+     * Zero-initialization prevents drawing on an invalid canvas size, i.e., a canvas size [1, 1] is technically valid
+     * for rendering, which might lead to rendering on an [1, 1] canvas before the first 'real' size is set (e.g., via
+     * resize event), resulting in visually unpleasant initial frames in some (slow) applications.
      */
-    protected _size: GLsizei2 = [1, 1];
+    protected _size: GLsizei2 = [0, 0];
     protected _sizeSubject = new ReplaySubject<GLsizei2>(1);
 
     /**
@@ -261,7 +264,7 @@ export class Canvas extends Resizable {
         /* If the canvas does not have a size, block rendering. This can happen if the canvas is, e.g., hidden and
         DOM layouting leads to width of zero. */
         if (this._size[0] === 0 || this._size[1] === 0) {
-            log(LogLevel.Warning, `canvas width or height is invalid, resize discarded and controller blocked`);
+            log(LogLevel.Debug, `canvas width or height is invalid, resize discarded and controller blocked`);
             this._controller.block();
             return;
         }


### PR DESCRIPTION
Zero-initialization prevents drawing on an invalid canvas size, i.e., a canvas size [1, 1] is technically valid for rendering, which might lead to rendering on an [1, 1] canvas before the first 'real' size is set (e.g., via resize event), resulting in visually unpleasant initial frames in some (slow) applications.