### PR TITLE
Handle masquerade conceil when creating context hash

### DIFF
--- a/source/context.ts
+++ b/source/context.ts
@@ -879,13 +879,7 @@ export class Context {
      * Provides the context's extension hash. The hash can be used for context masquerade.
      */
     hash(): string {
-        // Handle masquerade
-        let extensions = this._extensions;
-        if (this._mask) {
-            extensions = extensions.filter((extension) => this._mask!.extensionsConceal.indexOf(extension) === -1);
-        }
-
-        return ExtensionsHash.encode(this._backend as Context.BackendType, extensions);
+        return ExtensionsHash.encode(this._backend as Context.BackendType, this._extensions);
     }
 
     /**

--- a/source/context.ts
+++ b/source/context.ts
@@ -356,7 +356,12 @@ export class Context {
             return;
         }
 
+        // Only handle masquerade here and not within each supports-query?
         for (const extension of extensions) {
+            if (this._mask && this._mask.extensionsConceal.indexOf(extension) > -1) {
+                continue;
+            }
+
             this._extensions.push(extension);
         }
 
@@ -874,7 +879,13 @@ export class Context {
      * Provides the context's extension hash. The hash can be used for context masquerade.
      */
     hash(): string {
-        return ExtensionsHash.encode(this._backend as Context.BackendType, this._extensions);
+        // Handle masquerade
+        let extensions = this._extensions;
+        if (this._mask) {
+            extensions = extensions.filter((extension) => this._mask!.extensionsConceal.indexOf(extension) === -1);
+        }
+
+        return ExtensionsHash.encode(this._backend as Context.BackendType, extensions);
     }
 
     /**

--- a/source/extensionshash.ts
+++ b/source/extensionshash.ts
@@ -139,32 +139,32 @@ export class ExtensionsHash {
         assert(hash.length === expectedHashLength,
             `expected hash of version ${version} to have a length of ${expectedHashLength}, given ${hash}`);
 
-        const supported = new Array<string>();
+        const strived = new Array<string>();
         for (let i = 1; i < hash.length; ++i) {
             const bitfield = ExtensionsHash.decode64(hash[i]);
             const offset = (i - 1) * 6;
 
             /* loop explicitly unrolled */
             if (bitfield & 0b100000) {
-                supported.push(extensions[offset + 0]);
+                strived.push(extensions[offset + 0]);
             }
             if (bitfield & 0b010000) {
-                supported.push(extensions[offset + 1]);
+                strived.push(extensions[offset + 1]);
             }
             if (bitfield & 0b001000) {
-                supported.push(extensions[offset + 2]);
+                strived.push(extensions[offset + 2]);
             }
             if (bitfield & 0b000100) {
-                supported.push(extensions[offset + 3]);
+                strived.push(extensions[offset + 3]);
             }
             if (bitfield & 0b000010) {
-                supported.push(extensions[offset + 4]);
+                strived.push(extensions[offset + 4]);
             }
             if (bitfield & 0b000001) {
-                supported.push(extensions[offset + 5]);
+                strived.push(extensions[offset + 5]);
             }
         }
-        return [backend, supported];
+        return [backend, strived];
     }
 
     /**

--- a/source/gl2facade.ts
+++ b/source/gl2facade.ts
@@ -24,7 +24,6 @@ export class GL2Facade {
 
     /**
      * @param context - Wrapped gl context for function resolution.
-     * @param extensions - Identifiers of mandatory extensions for which the support is asserted.
      */
     constructor(context: Context) {
         assert(context !== undefined, `gl2 facade expects a valid WebGL context`);

--- a/source/gl2facade.ts
+++ b/source/gl2facade.ts
@@ -216,7 +216,7 @@ export class GL2Facade {
     vertexAttribDivisor: (index: GLuint, divisor: GLuint) => void;
 
     /**
-     * Evaluate wether or not ANGLE_instanced_arrays is supported (either by extension or in WebGL2 by default) and, if
+     * Evaluate whether or not ANGLE_instanced_arrays is supported (either by extension or in WebGL2 by default) and, if
      * supported, binds the associated functions.
      * @param context - WebGL context to query extension support in
      */
@@ -251,10 +251,9 @@ export class GL2Facade {
     drawBuffers: ((buffers: Array<GLenum>) => void) | undefined = undefined;
 
     /**
-     * Evaluate wether or not WEBGL_draw_buffers is supported (either by extension or in WebGL2 by default) and, if
+     * Evaluate whether or not WEBGL_draw_buffers is supported (either by extension or in WebGL2 by default) and, if
      * supported, binds the associated functions.
      * @param context - WebGL context to query extension support in.
-     * @returns - True if WEBGL_draw_buffers is supported and associated functions are bound.
      */
     protected queryDrawBuffersSupport(context: Context): void {
         if (!context.isWebGL2 && !context.supportsDrawBuffers) {

--- a/test/contextmasquerade.test.ts
+++ b/test/contextmasquerade.test.ts
@@ -73,6 +73,14 @@ describe('ContextMasquerade', () => {
         expect(masquerade.extensionsConceal).to.include('WEBGL_draw_buffers');
     });
 
+    it('should be initializable from hash w.r.t. draw buffers extension', () => {
+        const masquerade = ContextMasquerade.fromHash('1Q+++Z');
+        expect(masquerade.backend).to.equal('webgl1');
+        expect(masquerade.extensionsStrive).to.not.include('WEBGL_draw_buffers');
+        expect(masquerade.functionsUndefine).to.be.empty;
+        expect(masquerade.extensionsConceal).to.include('WEBGL_draw_buffers');
+    });
+
     it('should be initializable by GET using hash', () => {
         const getParameterStub = sandbox.stub(aux, 'GETparameter');
         getParameterStub.returns('1w0000');

--- a/test/extensionshash.test.ts
+++ b/test/extensionshash.test.ts
@@ -6,7 +6,7 @@ import * as chai from 'chai';
 const expect = chai.expect;
 
 import { Context } from '../source/context';
-import { WEBGL2_EXTENSIONS } from '../source/extensions';
+import { WEBGL1_EXTENSIONS, WEBGL2_EXTENSIONS } from '../source/extensions';
 import { ExtensionsHash } from '../source/extensionshash';
 
 /* spellchecker: enable */
@@ -107,7 +107,7 @@ describe('ExtensionsHash', () => {
         expect(ExtensionsHash.decode('1+0000')[1]).to.deep.equal(FIRST_6_000_EXTENSIONS);
     });
 
-    it('should complement a set of extensions', () => {
+    it('should complement a set of extensions for webgl2', () => {
         const SOME_WEBGL2_EXTS = ['EXT_color_buffer_float', 'EXT_disjoint_timer_query_webgl2',
             'EXT_texture_filter_anisotropic', 'OES_texture_float_linear', 'OES_texture_half_float_linear'];
         const complement = ExtensionsHash.complement('webgl2', SOME_WEBGL2_EXTS);
@@ -117,6 +117,17 @@ describe('ExtensionsHash', () => {
 
         expect(WEBGL2_EXTENSIONS).to.contains.members(complement);
         expect(WEBGL2_EXTENSIONS).to.contains.members(SOME_WEBGL2_EXTS);
+    });
+
+    it('should complement a set of extensions for webgl1', () => {
+        const SOME_WEBGL1_EXTS = ['ANGLE_instanced_arrays', 'WEBGL_draw_buffers'];
+        const complement = ExtensionsHash.complement('webgl1', SOME_WEBGL1_EXTS);
+        expect(complement.length + SOME_WEBGL1_EXTS.length).to.equal(WEBGL1_EXTENSIONS.length);
+
+        expect(complement).to.not.deep.include(SOME_WEBGL1_EXTS);
+
+        expect(WEBGL1_EXTENSIONS).to.contains.members(complement);
+        expect(WEBGL1_EXTENSIONS).to.contains.members(SOME_WEBGL1_EXTS);
     });
 
 });


### PR DESCRIPTION
This PR starts a discussion on masquerade conceil behavior.

As of the current master, the masquerade is only considered when using the `supports` function of the context object. When requesting the `hash` fromthe context, the conceiled extensions from the masquerade are ignored.

The first question is: Is this expected behavior?

If no, then this PR provides two possible solutions to handle the masquerade to its full extent when creating the hash:
1. Dropping queried WebGL extensions during `queryExtensionSupport`
2. Dropping supported extensions during `hash`