### PR TITLE
Field of View configuration

### DIFF
--- a/source/camera.ts
+++ b/source/camera.ts
@@ -4,7 +4,7 @@
 import { mat4, vec3 } from 'gl-matrix';
 import { m4 } from './gl-matrix-extensions';
 
-import { DEG2RAD, log, LogLevel } from './auxiliaries';
+import { DEG2RAD, log, LogLevel, RAD2DEG } from './auxiliaries';
 import { duplicate2, GLsizei2 } from './tuples';
 
 /* spellchecker: enable */
@@ -179,7 +179,7 @@ export class Camera {
     }
 
     /**
-     * Sets the vertical field-of-view. Invalidates the projection.
+     * Sets the vertical field-of-view in degrees. Invalidates the projection.
      */
     set fovy(fovy: GLfloat) {
         if (this._fovy === fovy) {
@@ -187,6 +187,36 @@ export class Camera {
         }
         this._fovy = fovy;
         this.invalidate(false, true);
+    }
+
+    /**
+     * Sets the horizontal field-of-view in degrees. Invalidates the projection.
+     * Note that internally, this will be translated to the corresponding the vertical field.
+     */
+    set fovx(fovx: GLfloat) {
+        const horizontalAngle = fovx * DEG2RAD;
+        const verticalAngle = 2.0 * Math.atan(Math.tan(horizontalAngle / 2.0) * (1.0 / this.aspect));
+
+        const fovy = verticalAngle * RAD2DEG;
+        if (this._fovy === fovy) {
+            return;
+        }
+        this._fovy = fovy;
+        this.invalidate(false, true);
+    }
+
+    /**
+     * With this function the view of a physical camera can be emulated. The width and focal length of
+     * a lens are used to generate the correct field of view.
+     * Blender camera presets can be imported by using the camera setting 'HorizontalFit' and using the
+     * width and focal length values in this function.
+     * See: https://www.scantips.com/lights/fieldofviewmath.html
+     * @param sensorWidth - Width of the sensor in mm
+     * @param focalLength - Focal length of the lens in mm
+     */
+    fovFromLens(sensorWidth: number, focalLength: number): void {
+        const horizontalAngle = 2.0 * Math.atan(sensorWidth / (2.0 * focalLength));
+        this.fovx = horizontalAngle * RAD2DEG;
     }
 
     /**

--- a/test/camera.test.ts
+++ b/test/camera.test.ts
@@ -1,0 +1,43 @@
+
+/* spellchecker: disable */
+
+import * as chai from 'chai';
+import * as spies from 'chai-spies';
+
+chai.use(spies);
+
+const expect = chai.expect;
+
+import { Camera } from '../source/camera';
+
+/* spellchecker: enable */
+
+
+/* tslint:disable:no-unused-expression */
+
+describe('field of view', () => {
+
+    it('should be initializable as fovy', () => {
+        const camera = new Camera();
+        camera.fovy = 90.0;
+
+        expect(camera.fovy).to.be.closeTo(90.0, 1e-8);
+    });
+
+    it('should be initializable as fovx', () => {
+        const camera = new Camera();
+        camera.aspect = 16 / 9;
+        camera.fovx = 90.0;
+
+        expect(camera.fovy).to.be.closeTo(58.7155, 0.0001);
+    });
+
+    it('should be initializable via physical camera settings', () => {
+        const camera = new Camera();
+        camera.aspect = 16 / 9;
+        camera.fovFromLens(50, 50);
+
+        expect(camera.fovy).to.be.closeTo(31.4172, 0.0001);
+    });
+
+});


### PR DESCRIPTION
See #79. This adds the possibilities to set the camera field of view via horizontal fov (setter `fovx`) or physical camera properties (method `fovFromLens`)