### PR TITLE
UnifiedBuffer

### DIFF
--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -1,0 +1,127 @@
+
+/* spellchecker: disable */
+
+import { Buffer } from './buffer';
+import { Context } from './context';
+import { Initializable } from './initializable';
+
+/* spellchecker: enable */
+
+
+export class UnifiedBuffer extends Initializable {
+
+    protected _cpuBuffer: ArrayBuffer;
+    protected _gpuBuffer: Buffer;
+    protected _usage: GLenum;
+
+    protected _updates = new Array<Update>();
+
+    constructor(context: Context, sizeInBytes: number, usage: GLenum, identifier?: string) {
+        super();
+
+        this._cpuBuffer = new ArrayBuffer(sizeInBytes);
+        this._gpuBuffer = new Buffer(context, identifier);
+        this._usage = usage;
+    }
+
+    protected _addUpdate(update: Update): void {
+        const toAdd = new Array<Update>();
+        const toRemove = new Array<number>();
+
+        this._updates.forEach((current: Update, index: number) => {
+            if (current.begin >= update.begin && current.end <= update.end) {
+                toRemove.push(index);
+            } else if (current.begin >= update.begin && current.end >= update.end) {
+                toAdd.push({ begin: update.end, end: current.end });
+                toRemove.push(index);
+            } else if (current.begin <= update.begin && current.end <= update.end) {
+                toAdd.push({ begin: current.begin, end: update.begin });
+                toRemove.push(index);
+            } else if (current.begin <= update.begin && current.end >= update.end) {
+                toAdd.push({ begin: current.begin, end: update.begin });
+                toAdd.push({ begin: update.end, end: current.end });
+                toRemove.push(index);
+            }
+        });
+
+        for (let index = toRemove.length - 1; index >= 0; index--) {
+            this._updates.splice(toRemove[index], 1);
+        }
+
+        this._updates.push(...toAdd);
+
+        this._updates.push(update);
+    }
+
+    @Initializable.initialize()
+    initialize(target: GLenum): boolean {
+        return this._gpuBuffer.initialize(target);
+    }
+
+    @Initializable.uninitialize()
+    uninitialize(): void {
+        this._gpuBuffer.uninitialize();
+
+        this.subData(0, new Float32Array());
+    }
+
+    @Initializable.assert_initialized()
+    bind(): void {
+        this._gpuBuffer.bind();
+    }
+
+    @Initializable.assert_initialized()
+    unbind(): void {
+        this._gpuBuffer.unbind();
+    }
+
+    @Initializable.assert_initialized()
+    attribEnable(index: GLuint, size: GLint, type: GLenum, normalized: GLboolean = false,
+        stride: GLsizei = 0, offset: GLintptr = 0, bind: boolean = true, unbind: boolean = true): void {
+        this._gpuBuffer.attribEnable(index, size, type, normalized, stride, offset, bind, unbind);
+    }
+
+    @Initializable.assert_initialized()
+    attribDisable(index: GLuint, bind: boolean = true, unbind: boolean = true): void {
+        this._gpuBuffer.attribDisable(index, bind, unbind);
+    }
+
+    subData(dstByteOffset: GLintptr, srcData: ArrayBufferView | ArrayBuffer): void {
+        const buffer = (srcData instanceof ArrayBuffer) ? srcData : srcData.buffer;
+
+        const src = new Uint8Array(buffer);
+        const dst = new Uint8Array(this._cpuBuffer);
+
+        dst.set(src, dstByteOffset);
+        this._addUpdate({ begin: dstByteOffset, end: dstByteOffset + src.byteLength });
+    }
+
+    @Initializable.assert_initialized()
+    update(bind: boolean = false, unbind: boolean = false): void {
+        if (bind) {
+            this._gpuBuffer.bind();
+        }
+
+        if (this._gpuBuffer.bytes === 0) {
+            this._gpuBuffer.data(this._cpuBuffer, this._usage);
+        } else {
+            for (const update of this._updates) {
+                this._gpuBuffer.subData(update.begin, this._cpuBuffer, update.begin, update.end - update.begin);
+            }
+        }
+
+        if (unbind) {
+            this._gpuBuffer.unbind();
+        }
+
+        this._updates.length = 0;
+    }
+
+}
+
+interface Update {
+    /** inclusive */
+    begin: number;
+    /** exclusive */
+    end: number;
+}

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -8,6 +8,42 @@ import { Initializable } from './initializable';
 /* spellchecker: enable */
 
 
+/**
+ * Class to encapsulating a WebGL buffer adding functionality to record changes to the underlying buffer without
+ * instantly propagating them to the WebGL buffer. It is intended to be a direct replacement for {@link Buffer}.
+ * When calling {@link subData} the data will be copied to an internal, CPU-sided buffer and the affecting range will be
+ * recorded. If the newly recorded range overrides a part of or the whole of a previously recorded range the older one
+ * will either be discarded completely or merged with the new one according to a specifiable merge threshold.
+ * To propagate all recorded changes to the GPU-sided buffer, {@link update} has to be called. This will take care of
+ * both the allocation of the GPU-sided buffer and the transfer of the changed data.
+ * While {@link update} can must only be called after initializing the object, {@link subData},
+ * {@link mergeSubDataRanges} and resizing (@see{@link size}) can be called on the unitialized object.
+ * The GPU-sided buffer is created on initialization and deleted on uninitialization.
+ * A typical usage could look like this:
+ * ```
+ * // Create a unified buffer with the size of 1028 bytes and a mergeThreshold of 32 bytes
+ * const unifiedBuffer = new UnifiedBuffer(context, 1028, gl.STATIC_DRAW, 32, 'UnifiedBuffer');
+ * unifiedBuffer.initialize(gl.ARRAY_BUFFER);
+ * unifiedBuffer.attribEnable(0, 1, gl.FLOAT, gl.FALSE, 0, 0, true, false);
+ * unifiedBuffer.attribEnable(1, 1, gl.SHORT, gl.FALSE, 0, 512, false, true);
+ *
+ * unifiedBuffer.subData(0, new Float32Array(64).fill(3.14));
+ * unifiedBuffer.subData(512, new Int16Array(128).fill(1200));
+ *
+ * unifiedBuffer.update(true, true);
+ *
+ * unifiedBuffer.subData(128, new Float32Array(32).fill(1.57));
+ * unifiedBuffer.subData(640, new Int36Array(64).fill(600));
+ *
+ * unifiedBuffer.mergeThreshold = -1;
+ * // This will merge both already existing ranges resulting in a single update
+ * unifiedBuffer.mergeSubDataRanges();
+ *
+ * unifiedBuffer.bind();
+ * unifiedBuffer.update();
+ * unifiedBuffer.unbind();
+ * ```
+ */
 export class UnifiedBuffer extends Initializable {
 
     protected _cpuBuffer: ArrayBuffer;
@@ -16,10 +52,26 @@ export class UnifiedBuffer extends Initializable {
     protected _usage: GLenum;
     protected _mergeThreshold: number;
 
+    /**
+     * Checks if two updates have to be merged according to the mergeThreshold. Note: lhsUpdate.begin has to be smaller
+     * than rhsUpdate.begin.
+     * @param lhsUpdate - First update
+     * @param rhsUpdate - Second update
+     * @param mergeThreshold - Threshold considered for merging.
+     * @returns - True if mergeThreshold == -1 or distance between the two updates <= mergeThreshold, false otherwise.
+     */
     protected static updatesNeedMerge(lhsUpdate: Update, rhsUpdate: Update, mergeThreshold: number): boolean {
         return rhsUpdate.begin - lhsUpdate.end < mergeThreshold || mergeThreshold === -1;
     }
 
+    /**
+     * Creates a zero initialized buffer with the given size.
+     * @param context - Context used for all GPU operations.
+     * @param sizeInBytes - Size of the buffer in bytes.
+     * @param usage - Usage hint for allocation of the GPU-sided buffer.
+     * @param mergeThreshold - Threshold in which all updates will get merged.
+     * @param identifier - Unique identifier for this UnifiedBuffer.
+     */
     constructor(context: Context, sizeInBytes: number, usage: GLenum, mergeThreshold = 0, identifier?: string) {
         super();
 
@@ -30,10 +82,10 @@ export class UnifiedBuffer extends Initializable {
     }
 
     /**
-     * Merges all updates left of index transitively with the update at index
-     * until there are no more updates within the merge threshold.
-     * @param index - Index of the update that should get merged
-     * @returns - Number of merged updates
+     * Merges all updates left of index transitively with the update at index until there are no more updates within the
+     * merge threshold.
+     * @param index - Index of the update that should get merged.
+     * @returns - Number of merged updates.
      */
     protected mergeUpdatesLeft(index: number): number {
         let removeCount = 0;
@@ -57,10 +109,10 @@ export class UnifiedBuffer extends Initializable {
     }
 
     /**
-     * Merges all updates right of index transitively with the update at index
-     * until there are no more updates within the merge threshold.
-     * @param index - Index of the update that should get merged
-     * @returns - Number of merged updates
+     * Merges all updates right of index transitively with the update at index until there are no more updates within
+     * the merge threshold.
+     * @param index - Index of the update that should get merged.
+     * @returns - Number of merged updates.
      */
     protected mergeUpdatesRight(index: number): number {
         let removeCount = 0;
@@ -83,6 +135,11 @@ export class UnifiedBuffer extends Initializable {
         return removeCount + 1;
     }
 
+    /**
+     * Adds a range to recorded updates. Transitively merges all already recorded updates within the mergeThreshold of
+     * the added range.
+     * @param update - Range to add to the updates.
+     */
     protected addUpdate(update: Update): void {
         const start = this._updates.findIndex((current: Update) => {
             return update.begin < current.begin;
@@ -100,32 +157,62 @@ export class UnifiedBuffer extends Initializable {
         }
     }
 
+    /**
+     * Create the buffer object on the GPU.
+     * @param target - Target used as binding point.
+     */
     @Initializable.initialize()
     initialize(target: GLenum): boolean {
         return this._gpuBuffer.initialize(target);
     }
 
+    /**
+     * Delete the buffer object on the GPU. This should have the reverse effect of `create`.
+     */
     @Initializable.uninitialize()
     uninitialize(): void {
         this._gpuBuffer.uninitialize();
     }
 
+    /**
+     * Binds the buffer object as buffer to predefined target.
+     */
     @Initializable.assert_initialized()
     bind(): void {
         this._gpuBuffer.bind();
     }
 
+    /**
+     * Binds null as current buffer to predefined target;
+     */
     @Initializable.assert_initialized()
     unbind(): void {
         this._gpuBuffer.unbind();
     }
 
+    /**
+     * Specifies the memory layout of the buffer for a binding point.
+     * @param index - Index of the vertex attribute that is to be setup and enabled.
+     * @param size - Number of components per vertex attribute.
+     * @param type - Data type of each component in the array.
+     * @param normalized - Whether integer data values should be normalized when being casted to a float.
+     * @param stride - Offset in bytes between the beginning of consecutive vertex attributes.
+     * @param offset - Offset in bytes of the first component in the vertex attribute array.
+     * @param bind - Allows to skip binding the object (e.g., when binding is handled outside).
+     * @param unbind - Allows to skip unbinding the object (e.g., when binding is handled outside).
+     */
     @Initializable.assert_initialized()
     attribEnable(index: GLuint, size: GLint, type: GLenum, normalized: GLboolean = false,
         stride: GLsizei = 0, offset: GLintptr = 0, bind: boolean = true, unbind: boolean = true): void {
         this._gpuBuffer.attribEnable(index, size, type, normalized, stride, offset, bind, unbind);
     }
 
+    /**
+     * Disables a buffer binding point.
+     * @param index - Index of the vertex attribute that is to be disabled.
+     * @param bind - Allows to skip binding the object (e.g., when binding is handled outside).
+     * @param unbind - Allows to skip unbinding the object (e.g., when binding is handled outside).
+     */
     @Initializable.assert_initialized()
     attribDisable(index: GLuint, bind: boolean = true, unbind: boolean = true): void {
         this._gpuBuffer.attribDisable(index, bind, unbind);
@@ -141,6 +228,13 @@ export class UnifiedBuffer extends Initializable {
         }
     }
 
+    /**
+     * Copies the new data into the CPU-sided buffer and records the range as changed. All previously added ranges will
+     * get merged transitively with the new one, if they are within the set mergeThreshold.
+     * Note: This does not transfer anything to the GPU-sided buffer yet.
+     * @param dstByteOffset - Offset of bytes into the destination buffer.
+     * @param srcData - Data that will be copied into the destination buffer.
+     */
     subData(dstByteOffset: GLintptr, srcData: ArrayBufferView | ArrayBuffer): void {
         let src: Uint8Array;
         if (srcData instanceof ArrayBuffer) {
@@ -155,6 +249,12 @@ export class UnifiedBuffer extends Initializable {
         this.addUpdate({ begin: dstByteOffset, end: dstByteOffset + src.byteLength });
     }
 
+    /**
+     * Copies all previously recorded ranges and their data to the GPU. (Re-)Allocate the GPU-sided buffer if the size
+     * changed or the object was reinitialized.
+     * @param bind - Allows to skip binding the object (e.g., when binding is handled outside).
+     * @param unbind - Allows to skip unbinding the object (e.g., when binding is handled outside).
+     */
     @Initializable.assert_initialized()
     update(bind: boolean = false, unbind: boolean = false): void {
         if (bind) {
@@ -178,10 +278,18 @@ export class UnifiedBuffer extends Initializable {
         this._updates.length = 0;
     }
 
+    /**
+     * Returns the size of the CPU-sided buffer. This is not necessarily the same as the size of the GPU-sided buffer,
+     * if update has not been called after resizing the buffer.
+     */
     get size(): number {
         return this._cpuBuffer.byteLength;
     }
 
+    /**
+     * Resizes the buffer. Note, that this does not resize the GPU-sided buffer. To update the size of the GPU-sided
+     * buffer update has to be called.
+     */
     set size(sizeInBytes: number) {
         const oldBuffer = this._cpuBuffer;
         this._cpuBuffer = new ArrayBuffer(sizeInBytes);
@@ -193,18 +301,40 @@ export class UnifiedBuffer extends Initializable {
         dst.set(src);
     }
 
+    /**
+     * Target to which the buffer object is bound (either GL_ARRAY_BUFFER or GL_ELEMENT_ARRAY_BUFFER).
+     * Readonly access to the target (as specified on initialization) the buffer will be bound to.
+     */
+    get target(): GLenum | undefined {
+        this.assertInitialized();
+        return this._gpuBuffer.target;
+    }
+
+    /**
+     * Returns the usage hint used for allocation of the GPU-sided buffer.
+     */
     get usage(): GLenum {
         return this._usage;
     }
 
+    /**
+     * Sets the usage hint used for allocation of the GPU-sided buffer.
+     */
     set usage(usage: GLenum) {
         this._usage = usage;
     }
 
+    /**
+     * Returns the threshold used to determine whether two ranges have to be merged.
+     */
     get mergeThreshold(): number {
         return this._mergeThreshold;
     }
 
+    /**
+     * Sets the threshold determining whether two ranges have to be merged. If the mergeThreshold is set to -1 all
+     * ranges will get merged disregarding their distance to each other.
+     */
     set mergeThreshold(mergeThreshold: number) {
         this._mergeThreshold = mergeThreshold;
     }

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -87,9 +87,13 @@ export class UnifiedBuffer extends Initializable {
     }
 
     subData(dstByteOffset: GLintptr, srcData: ArrayBufferView | ArrayBuffer): void {
-        const buffer = (srcData instanceof ArrayBuffer) ? srcData : srcData.buffer;
+        let src: Uint8Array;
+        if (srcData instanceof ArrayBuffer) {
+            src = new Uint8Array(srcData);
+        } else {
+            src = new Uint8Array(srcData.buffer).subarray(srcData.byteOffset, srcData.byteOffset + srcData.byteLength);
+        }
 
-        const src = new Uint8Array(buffer);
         const dst = new Uint8Array(this._cpuBuffer);
 
         dst.set(src, dstByteOffset);

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -13,18 +13,17 @@ export class UnifiedBuffer extends Initializable {
     protected _cpuBuffer: ArrayBuffer;
     protected _gpuBuffer: Buffer;
     protected _updates = new Array<Update>();
-
-    usage: GLenum;
+    protected _usage: GLenum;
 
     constructor(context: Context, sizeInBytes: number, usage: GLenum, identifier?: string) {
         super();
 
         this._cpuBuffer = new ArrayBuffer(sizeInBytes);
         this._gpuBuffer = new Buffer(context, identifier);
-        this.usage = usage;
+        this._usage = usage;
     }
 
-    protected _addUpdate(update: Update): void {
+    protected addUpdate(update: Update): void {
         const toRemove = new Array<number>();
         const toMerge = new Array<Update>();
 
@@ -92,7 +91,7 @@ export class UnifiedBuffer extends Initializable {
         const dst = new Uint8Array(this._cpuBuffer);
 
         dst.set(src, dstByteOffset);
-        this._addUpdate({ begin: dstByteOffset, end: dstByteOffset + src.byteLength });
+        this.addUpdate({ begin: dstByteOffset, end: dstByteOffset + src.byteLength });
     }
 
     @Initializable.assert_initialized()
@@ -102,7 +101,7 @@ export class UnifiedBuffer extends Initializable {
         }
 
         if (this._gpuBuffer.bytes !== this._cpuBuffer.byteLength) {
-            this._gpuBuffer.data(this._cpuBuffer, this.usage);
+            this._gpuBuffer.data(this._cpuBuffer, this._usage);
         } else {
             const bufferView = new Uint8Array(this._cpuBuffer);
             for (const update of this._updates) {
@@ -131,6 +130,14 @@ export class UnifiedBuffer extends Initializable {
         const src = new Uint8Array(oldBuffer).slice(0, sizeInBytes);
         const dst = new Uint8Array(this._cpuBuffer);
         dst.set(src);
+    }
+
+    get usage(): GLenum {
+        return this._usage;
+    }
+
+    set usage(usage: GLenum) {
+        this._usage = usage;
     }
 }
 

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -49,7 +49,11 @@ export class UnifiedBuffer extends Initializable {
     protected _cpuBuffer: ArrayBuffer;
     protected _gpuBuffer: Buffer;
     protected _updates = new Array<Update>();
+    
+    /** @see {@link usage} */
     protected _usage: GLenum;
+    
+    /** @see {@link mergeThreshold} */
     protected _mergeThreshold: number;
 
     /**

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -58,8 +58,6 @@ export class UnifiedBuffer extends Initializable {
     @Initializable.uninitialize()
     uninitialize(): void {
         this._gpuBuffer.uninitialize();
-
-        this.subData(0, new Float32Array());
     }
 
     @Initializable.assert_initialized()
@@ -125,7 +123,12 @@ export class UnifiedBuffer extends Initializable {
     set size(sizeInBytes: number) {
         const oldBuffer = this._cpuBuffer;
         this._cpuBuffer = new ArrayBuffer(sizeInBytes);
-        new Uint8Array(this._cpuBuffer).set(new Uint8Array(oldBuffer).slice(0, sizeInBytes));
+
+        // Takes the whole buffer, if sizeInBytes > oldBuffer
+        // Takes sizeInBytes of oldBuffer otherwise
+        const src = new Uint8Array(oldBuffer).slice(0, sizeInBytes);
+        const dst = new Uint8Array(this._cpuBuffer);
+        dst.set(src);
     }
 }
 

--- a/source/unifiedbuffer.ts
+++ b/source/unifiedbuffer.ts
@@ -104,8 +104,10 @@ export class UnifiedBuffer extends Initializable {
         if (this._gpuBuffer.bytes !== this._cpuBuffer.byteLength) {
             this._gpuBuffer.data(this._cpuBuffer, this.usage);
         } else {
+            const bufferView = new Uint8Array(this._cpuBuffer);
             for (const update of this._updates) {
-                this._gpuBuffer.subData(update.begin, this._cpuBuffer, update.begin, update.end - update.begin);
+                const subBufferView = bufferView.subarray(update.begin, update.end);
+                this._gpuBuffer.subData(update.begin, subBufferView);
             }
         }
 

--- a/source/webgl-operate.slim.ts
+++ b/source/webgl-operate.slim.ts
@@ -29,6 +29,7 @@ export { Shader } from './shader';
 export { Texture2D } from './texture2d';
 export { Texture3D } from './texture3d';
 export { TextureCube } from './texturecube';
+export { UnifiedBuffer } from './unifiedbuffer';
 export { VertexArray } from './vertexarray';
 export { Wizard } from './wizard';
 

--- a/test/unifiedbuffer.test.ts
+++ b/test/unifiedbuffer.test.ts
@@ -1,0 +1,281 @@
+
+/* spellchecker: disable */
+
+import * as chai from 'chai';
+// import * as sinon from 'sinon';
+
+const expect = chai.expect;
+// const stub = sinon.stub;
+
+import { AllocationRegister } from '../source/allocationregister';
+import { Buffer } from '../source/buffer';
+import { Context } from '../source/context';
+import { UnifiedBuffer } from '../source/unifiedbuffer';
+
+/* spellchecker: enable */
+
+
+/* tslint:disable:max-classes-per-file no-unused-expression */
+
+interface SubDataCall {
+    dstOffset: number;
+    srcOffset: number;
+    length: number;
+    data: ArrayBuffer;
+}
+
+class ContextMock {
+    allocationRegister = new AllocationRegister();
+}
+
+class BufferMock extends Buffer {
+    _bytes = 0;
+
+    subDataCalls: Array<SubDataCall>;
+    dataCalled: boolean;
+
+    constructor(context: ContextMock) {
+        super(context as Context);
+
+        this.subDataCalls = new Array<SubDataCall>();
+        this.dataCalled = false;
+    }
+
+    create(target: GLenum): WebGLBuffer | undefined {
+        this._valid = true;
+        return undefined;
+    }
+
+    data(data: ArrayBufferView | ArrayBuffer | GLsizeiptr, usage: GLenum,
+        bind: boolean = true, unbind: boolean = true): void {
+        this.dataCalled = true;
+        this._bytes = typeof data === 'number' ? data : data.byteLength;
+    }
+
+    subData(dstByteOffset: GLintptr, srcData: ArrayBufferView | ArrayBuffer,
+        srcOffset: GLuint = 0, length: GLuint = 0, bind: boolean = true, unbind: boolean = true): void {
+        const buffer = srcData instanceof ArrayBuffer ? srcData : srcData.buffer;
+        const data = new Uint8Array(buffer).buffer.slice(srcOffset, srcOffset + length);
+        this.subDataCalls.push({ dstOffset: dstByteOffset, srcOffset, length, data });
+    }
+
+    get bytes(): number {
+        return this._bytes;
+    }
+}
+
+class UnifiedBufferMock extends UnifiedBuffer {
+    _gpuBuffer: BufferMock;
+    cpuBuffer = this._cpuBuffer;
+
+    constructor(context: ContextMock, size: number, usage: GLenum) {
+        super(context as Context, size, usage);
+
+        this._gpuBuffer = new BufferMock(context);
+    }
+}
+
+
+describe('UnifiedBuffer', () => {
+
+    it('should create buffer on gpu lazily', () => {
+        const context = new ContextMock();
+        const buffer = new UnifiedBufferMock(context, 32, 0);
+
+        buffer.initialize(0);
+        expect(buffer._gpuBuffer.dataCalled).to.be.equal(false);
+
+        buffer.update();
+        expect(buffer._gpuBuffer.dataCalled).to.be.equal(true);
+    });
+
+    it('should work with different TypedArrays', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        buffer.subData(0, new Float32Array(8).fill(3456));
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(1);
+        expect(new Float32Array(buffer._gpuBuffer.subDataCalls[0].data)).to.be.eql(new Float32Array(8).fill(3456));
+
+        buffer._gpuBuffer.subDataCalls.length = 0;
+
+        buffer.subData(0, new Int32Array(8).fill(-2134));
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(1);
+        expect(new Int32Array(buffer._gpuBuffer.subDataCalls[0].data)).to.be.eql(new Int32Array(8).fill(-2134));
+    });
+});
+
+describe('UnifiedBuffer subData', () => {
+
+    it('should throw on data exceeding size', () => {
+        const context = new ContextMock();
+        const buffer = new UnifiedBufferMock(context, 32, 0);
+
+        expect(() => buffer.subData(0, new Uint8Array(64))).to.throw;
+        expect(() => buffer.subData(8, new Uint8Array(32))).to.throw;
+    });
+});
+
+describe('UnifiedBuffer update', () => {
+
+    it('should not make unnecessary subData calls', () => {
+        const context = new ContextMock();
+        const buffer = new UnifiedBufferMock(context, 32, 0);
+
+        buffer.initialize(0);
+
+        buffer.subData(0, new Uint8Array(32));
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(0);
+
+        buffer.subData(0, new Uint8Array(32));
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(1);
+    });
+
+    it('should discard old updates', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        buffer.subData(8, new Uint8Array(16).fill(1));
+        buffer.subData(8, new Uint8Array(16).fill(2));
+
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(1);
+    });
+
+    it('should split overlapping updates 1', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        /**
+         * _______
+         * |______| old
+         *    ________
+         *    |_______| new
+         */
+        buffer.subData(0, new Uint8Array(16).fill(1));
+        buffer.subData(8, new Uint8Array(16).fill(2));
+
+        buffer.update();
+
+        const expectedSubDataCalls = new Array<SubDataCall>(2);
+        expectedSubDataCalls[0] = { srcOffset: 0, dstOffset: 0, length: 8, data: new Uint8Array(8).fill(1) };
+        expectedSubDataCalls[1] = { srcOffset: 8, dstOffset: 8, length: 16, data: new Uint8Array(16).fill(2) };
+
+        const actualSubDataCalls = buffer._gpuBuffer.subDataCalls.map((subDataCall: SubDataCall) => {
+            return {
+                srcOffset: subDataCall.srcOffset,
+                dstOffset: subDataCall.dstOffset,
+                length: subDataCall.length,
+                data: new Uint8Array(subDataCall.data),
+            };
+        });
+
+        expect(actualSubDataCalls).to.be.eql(expectedSubDataCalls);
+    });
+
+    it('should split overlapping updates 2', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        /**
+         *    _______
+         *    |______| old
+         * ________
+         * |_______| new
+         */
+        buffer.subData(8, new Uint8Array(16).fill(1));
+        buffer.subData(0, new Uint8Array(16).fill(2));
+
+        buffer.update();
+
+        const expectedSubDataCalls = new Array<SubDataCall>(2);
+        expectedSubDataCalls[0] = { srcOffset: 16, dstOffset: 16, length: 8, data: new Uint8Array(8).fill(1) };
+        expectedSubDataCalls[1] = { srcOffset: 0, dstOffset: 0, length: 16, data: new Uint8Array(16).fill(2) };
+
+        const actualSubDataCalls = buffer._gpuBuffer.subDataCalls.map((subDataCall: SubDataCall) => {
+            return {
+                srcOffset: subDataCall.srcOffset,
+                dstOffset: subDataCall.dstOffset,
+                length: subDataCall.length,
+                data: new Uint8Array(subDataCall.data),
+            };
+        });
+
+        expect(actualSubDataCalls).to.be.eql(expectedSubDataCalls);
+    });
+
+    it('should split overlapping updates 3', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        /**
+         * ______________
+         * |_____________| old
+         *    ________
+         *    |_______| new
+         */
+        buffer.subData(0, new Uint8Array(32).fill(1));
+        buffer.subData(8, new Uint8Array(16).fill(2));
+
+        buffer.update();
+
+        const expectedSubDataCalls = new Array<SubDataCall>(3);
+        expectedSubDataCalls[0] = { srcOffset: 0, dstOffset: 0, length: 8, data: new Uint8Array(8).fill(1) };
+        expectedSubDataCalls[1] = { srcOffset: 24, dstOffset: 24, length: 8, data: new Uint8Array(8).fill(1) };
+        expectedSubDataCalls[2] = { srcOffset: 8, dstOffset: 8, length: 16, data: new Uint8Array(16).fill(2) };
+
+        const actualSubDataCalls = buffer._gpuBuffer.subDataCalls.map((subDataCall: SubDataCall) => {
+            return {
+                srcOffset: subDataCall.srcOffset,
+                dstOffset: subDataCall.dstOffset,
+                length: subDataCall.length,
+                data: new Uint8Array(subDataCall.data),
+            };
+        });
+
+        expect(actualSubDataCalls).to.be.eql(expectedSubDataCalls);
+    });
+
+    it('should split overlapping updates 4', () => {
+        const buffer = createUsableUnifiedBuffer(32);
+
+        /**
+         *    _______
+         *    |______| old
+         * ______________
+         * |_____________| new
+         */
+        buffer.subData(8, new Uint8Array(16).fill(1));
+        buffer.subData(0, new Uint8Array(32).fill(2));
+
+        buffer.update();
+
+        const expectedSubDataCalls = new Array<SubDataCall>(1);
+        expectedSubDataCalls[0] = { srcOffset: 0, dstOffset: 0, length: 32, data: new Uint8Array(32).fill(2) };
+
+        const actualSubDataCalls = buffer._gpuBuffer.subDataCalls.map((subDataCall: SubDataCall) => {
+            return {
+                srcOffset: subDataCall.srcOffset,
+                dstOffset: subDataCall.dstOffset,
+                length: subDataCall.length,
+                data: new Uint8Array(subDataCall.data),
+            };
+        });
+
+        expect(actualSubDataCalls).to.be.eql(expectedSubDataCalls);
+    });
+});
+
+function createUsableUnifiedBuffer(size: number): UnifiedBufferMock {
+    const context = new ContextMock();
+    const buffer = new UnifiedBufferMock(context as Context, 32, 0);
+
+    buffer.initialize(0);
+    buffer.update();
+
+    return buffer;
+}

--- a/test/unifiedbuffer.test.ts
+++ b/test/unifiedbuffer.test.ts
@@ -69,8 +69,8 @@ class BufferMock extends Buffer {
 class UnifiedBufferMock extends UnifiedBuffer {
     _gpuBuffer: BufferMock;
 
-    constructor(context: ContextMock, size: number, usage: GLenum) {
-        super(context as Context, size, usage);
+    constructor(context: ContextMock, size: number, mergeThreshold = 0) {
+        super(context as Context, size, 0, mergeThreshold);
 
         this._gpuBuffer = new BufferMock(context);
     }
@@ -85,7 +85,7 @@ describe('UnifiedBuffer', () => {
 
     it('should create buffer on gpu lazily', () => {
         const context = new ContextMock();
-        const buffer = new UnifiedBufferMock(context, 32, 0);
+        const buffer = new UnifiedBufferMock(context, 32);
 
         buffer.initialize(0);
         expect(buffer._gpuBuffer.dataCalled).to.be.false;
@@ -116,7 +116,7 @@ describe('UnifiedBuffer', () => {
 
     it('should keep content on resize', () => {
         const context = new ContextMock();
-        const buffer = new UnifiedBufferMock(context, 32, 0);
+        const buffer = new UnifiedBufferMock(context, 32);
 
         buffer.subData(0, new Float32Array(8).fill(17));
 
@@ -139,7 +139,7 @@ describe('UnifiedBuffer subData', () => {
 
     it('should throw on data exceeding size', () => {
         const context = new ContextMock();
-        const buffer = new UnifiedBufferMock(context, 32, 0);
+        const buffer = new UnifiedBufferMock(context, 32);
 
         expect(() => buffer.subData(0, new Uint8Array(64))).to.throw;
         expect(() => buffer.subData(8, new Uint8Array(32))).to.throw;
@@ -147,7 +147,7 @@ describe('UnifiedBuffer subData', () => {
 
     it('should work with subarrays', () => {
         const context = new ContextMock();
-        const buffer = new UnifiedBufferMock(context, 32, 0);
+        const buffer = new UnifiedBufferMock(context, 32);
 
         const tooBigArray = new ArrayBuffer(64);
         const tooBigArrayView = new Uint8Array(tooBigArray);
@@ -169,7 +169,7 @@ describe('UnifiedBuffer update', () => {
 
     it('should not make unnecessary subData calls', () => {
         const context = new ContextMock();
-        const buffer = new UnifiedBufferMock(context, 32, 0);
+        const buffer = new UnifiedBufferMock(context, 32);
 
         buffer.initialize(0);
 
@@ -311,11 +311,58 @@ describe('UnifiedBuffer update', () => {
 
         expect(mapSubDataCalls(buffer._gpuBuffer.subDataCalls)).to.be.eql(expectedSubDataCalls);
     });
+
+    it('should respect the merge threshold on non-overlapping ranges 1', () => {
+        const buffer = createUsableUnifiedBuffer(32, -1);
+
+        buffer.subData(0, new Uint8Array(8).fill(1));
+        buffer.subData(24, new Uint8Array(8).fill(2));
+
+        buffer.update();
+
+        const expectedData = new Uint8Array(32).fill(1, 0, 8).fill(2, 24, 32);
+        const expectedSubDataCalls = new Array<SubDataCall>(
+            { dstOffset: 0, data: expectedData });
+
+        expect(mapSubDataCalls(buffer._gpuBuffer.subDataCalls)).to.be.eql(expectedSubDataCalls);
+    });
+
+    it('should respect the merge threshold on non-overlapping ranges 2', () => {
+        const buffer = createUsableUnifiedBuffer(32, 4);
+
+        buffer.subData(0, new Uint8Array(8).fill(1));
+        buffer.subData(10, new Uint8Array(8).fill(2));
+        buffer.subData(24, new Uint8Array(8).fill(3));
+
+        buffer.update();
+
+        const expectedData = new Uint8Array(18).fill(1, 0, 8).fill(2, 10, 18);
+        const expectedSubDataCalls = new Array<SubDataCall>(
+            { dstOffset: 0, data: expectedData },
+            { dstOffset: 24, data: new Uint8Array(8).fill(3) });
+
+        expect(mapSubDataCalls(buffer._gpuBuffer.subDataCalls)).to.be.eql(expectedSubDataCalls);
+    });
+
+    it('should respect the merge threshold on overlapping ranges', () => {
+        const buffer = createUsableUnifiedBuffer(32, 4);
+
+        buffer.subData(8, new Uint8Array(8).fill(1));
+        buffer.subData(12, new Uint8Array(8).fill(2));
+
+        buffer.update();
+
+        const expectedData = new Uint8Array(12).fill(1, 0, 4).fill(2, 4, 12);
+        const expectedSubDataCalls = new Array<SubDataCall>(
+            { dstOffset: 8, data: expectedData });
+
+        expect(mapSubDataCalls(buffer._gpuBuffer.subDataCalls)).to.be.eql(expectedSubDataCalls);
+    });
 });
 
-function createUsableUnifiedBuffer(size: number): UnifiedBufferMock {
+function createUsableUnifiedBuffer(size: number, mergeThreshold = 0): UnifiedBufferMock {
     const context = new ContextMock();
-    const buffer = new UnifiedBufferMock(context as Context, 32, 0);
+    const buffer = new UnifiedBufferMock(context as Context, 32, mergeThreshold);
 
     buffer.initialize(0);
     buffer.update();

--- a/test/unifiedbuffer.test.ts
+++ b/test/unifiedbuffer.test.ts
@@ -360,6 +360,39 @@ describe('UnifiedBuffer update', () => {
     });
 });
 
+describe('UnifiedBuffer mergeSubDataRanges', () => {
+
+    it('should merge all ranges within threshold', () => {
+        const buffer = createUsableUnifiedBuffer(32, 0);
+
+        buffer.subData(0, new Uint8Array(8).fill(1));
+        buffer.subData(16, new Uint8Array(8).fill(2));
+        buffer.subData(30, new Uint8Array(2).fill(3));
+
+        buffer.mergeThreshold = 8;
+        buffer.mergeSubDataRanges();
+
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(2);
+    });
+
+    it('should merge all ranges if threshold == -1', () => {
+        const buffer = createUsableUnifiedBuffer(32, 0);
+
+        buffer.subData(0, new Uint8Array(8).fill(1));
+        buffer.subData(16, new Uint8Array(8).fill(2));
+        buffer.subData(30, new Uint8Array(2).fill(3));
+
+        buffer.mergeThreshold = -1;
+        buffer.mergeSubDataRanges();
+
+        buffer.update();
+
+        expect(buffer._gpuBuffer.subDataCalls.length).to.be.equal(1);
+    });
+});
+
 function createUsableUnifiedBuffer(size: number, mergeThreshold = 0): UnifiedBufferMock {
     const context = new ContextMock();
     const buffer = new UnifiedBufferMock(context as Context, 32, mergeThreshold);

--- a/test/unifiedbuffer.test.ts
+++ b/test/unifiedbuffer.test.ts
@@ -135,6 +135,22 @@ describe('UnifiedBuffer subData', () => {
         expect(() => buffer.subData(0, new Uint8Array(64))).to.throw;
         expect(() => buffer.subData(8, new Uint8Array(32))).to.throw;
     });
+
+    it('should work with subarrays', () => {
+        const context = new ContextMock();
+        const buffer = new UnifiedBufferMock(context, 32, 0);
+
+        const tooBigArray = new ArrayBuffer(64);
+        const subArray = new Uint8Array(tooBigArray).fill(13, 0, 16).fill(17, 16, 32).subarray(8, 24);
+
+        buffer.subData(0, subArray);
+        expect(() => buffer.subData(0, subArray)).to.not.throw;
+
+        const expected = new Uint8Array(32);
+        expected.fill(13, 0, 8);
+        expected.fill(17, 8, 16);
+        expect(new Uint8Array(buffer.cpuBuffer)).to.be.eql(expected);
+    });
 });
 
 describe('UnifiedBuffer update', () => {


### PR DESCRIPTION
Implements UnifiedBuffer concept.
It is intended to be used as a replacement for the [Buffer](https://github.com/cginternals/webgl-operate/blob/master/source/buffer.tsl), where applicable.
It tracks all `subData` calls internally and only updates the GPU-Buffer with the newest changed subsets when `update` is called.