### PR TITLE
Fixes behaviour of controller when it's blocked

### DIFF
--- a/source/controller.ts
+++ b/source/controller.ts
@@ -178,6 +178,7 @@ export class Controller {
     protected request(source: Controller.RequestType = Controller.RequestType.Frame): void {
         if (this._block) {
             this._blockedUpdates++;
+            this._animationFrameID = 0;
             return;
         }
 

--- a/source/controller.ts
+++ b/source/controller.ts
@@ -176,9 +176,10 @@ export class Controller {
 
 
     protected request(source: Controller.RequestType = Controller.RequestType.Frame): void {
+        this._animationFrameID = 0;
+
         if (this._block) {
             this._blockedUpdates++;
-            this._animationFrameID = 0;
             return;
         }
 

--- a/test/controller.test.ts
+++ b/test/controller.test.ts
@@ -127,6 +127,31 @@ describe('Controller', () => {
         expect(invokeStub.calledOnce).to.be.true;
     });
 
+    it('should render on unblock after already rendering before', () => {
+        const controller = new ControllerMock();
+
+        (global as any).window = {
+            requestAnimationFrame: () => {
+                controller.invoke(Controller.RequestType.Frame);
+                return ++ControllerMock.nextAnimationFrame;
+            },
+            cancelAnimationFrame: () => undefined,
+        };
+        const invokeStub = stub(controller, 'invoke');
+
+        controller.request();
+        expect(invokeStub.calledOnce).to.be.true;
+
+        invokeStub.reset();
+
+        controller.block();
+        controller.request();
+        expect(invokeStub.calledOnce).to.be.false;
+
+        controller.unblock();
+        expect(invokeStub.calledOnce).to.be.true;
+    });
+
     it('should not render when not initialized', () => {
         const controller = new ControllerMock();
 


### PR DESCRIPTION
Fixes controller for when it was already running, then blocked and finally unblocked again.
Previously no new request was generated.
Now unblock will correctly trigger a request again.