### PR TITLE
provide Debug.Mode.None in enum and use same numbers as in shader

### DIFF
--- a/source/debugpass.ts
+++ b/source/debugpass.ts
@@ -160,10 +160,11 @@ export class DebugPass extends BlitPass {
 export namespace DebugPass {
 
     export enum Mode {
-        Depth = 0,
-        DepthLinear = 1,
-        DepthPacked = 2,
-        DepthLinearPacked = 3,
+        None = 0,
+        Depth = 1,
+        DepthLinear = 2,
+        DepthPacked = 3,
+        DepthLinearPacked = 4,
     }
 
 }

--- a/source/shaders/blit_debug.frag
+++ b/source/shaders/blit_debug.frag
@@ -27,17 +27,19 @@ void main(void)
 {
     vec4 source = texture(u_source, v_uv);
 
-    if(u_mode == 0) {           /* Depth */
+    /* u_mode == 0                 None */
+
+    if(u_mode == 1) {           /* Depth */
         source.rgb = vec3(source[0]);
 
-    } else if (u_mode == 1) {   /* DepthLinear */
+    } else if (u_mode == 2) {   /* DepthLinear */
         float zLinear = linearizeDepth(source[0], u_linearize[0], u_linearize[1]);
         source.rgb = vec3(zLinear);
 
-    } else if(u_mode == 2) {    /* DepthPacked */
+    } else if(u_mode == 3) {    /* DepthPacked */
         source.rgb = float24x1_to_uint8x3(source[0]);
 
-    } else if (u_mode == 3) {   /* DepthLinearPacked */
+    } else if (u_mode == 4) {   /* DepthLinearPacked */
         float zLinear = linearizeDepth(source[0], u_linearize[0], u_linearize[1]);
         source.rgb = float24x1_to_uint8x3(zLinear);
     }

--- a/source/shaders/blit_debug.frag
+++ b/source/shaders/blit_debug.frag
@@ -27,17 +27,17 @@ void main(void)
 {
     vec4 source = texture(u_source, v_uv);
 
-    if(u_mode == 1) {           /* Depth */
+    if(u_mode == 0) {           /* Depth */
         source.rgb = vec3(source[0]);
 
-    } else if (u_mode == 2) {   /* DepthLinear */
+    } else if (u_mode == 1) {   /* DepthLinear */
         float zLinear = linearizeDepth(source[0], u_linearize[0], u_linearize[1]);
         source.rgb = vec3(zLinear);
 
-    } else if(u_mode == 3) {    /* DepthPacked */
+    } else if(u_mode == 2) {    /* DepthPacked */
         source.rgb = float24x1_to_uint8x3(source[0]);
 
-    } else if (u_mode == 4) {   /* DepthLinearPacked */
+    } else if (u_mode == 3) {   /* DepthLinearPacked */
         float zLinear = linearizeDepth(source[0], u_linearize[0], u_linearize[1]);
         source.rgb = float24x1_to_uint8x3(zLinear);
     }


### PR DESCRIPTION
This fixes #257 by providing a None mode (0).
Not having None means that the user needs to use any number outside the enum (to reset the debug mode), which seems hacky to me.