### PR TITLE
Check top frame params in GETparameter() and GETsearch()

### DIFF
--- a/source/auxiliaries.ts
+++ b/source/auxiliaries.ts
@@ -300,10 +300,14 @@ namespace auxiliaries {
     export const DEG2RAD = 0.017453292519943295;
 
     /**
-     * Queries window.location.search.
+     * Queries window.location.search, or, if not present, window.location.search of the window's top frame.
      */
     export function GETsearch(): string {
-        return window.location.search;
+        let search = window.location.search;
+        if (!search) {
+            search = window.top.location.search;
+        }
+        return search;
     }
 
     /**

--- a/source/auxiliaries.ts
+++ b/source/auxiliaries.ts
@@ -312,7 +312,11 @@ namespace auxiliaries {
      */
     export function GETparameter(parameter: string): string | undefined {
         const re = new RegExp(`${parameter}=([^&]+)`);
-        const match = window.location.search.match(re);
+        let match = window.location.search.match(re);
+        if (!match) {
+            // For iframe contents (i. e., the embedded /examples/ files), look within the top frame's search params
+            match = window.top.location.search.match(re);
+        }
         if (!match) {
             return undefined;
         }

--- a/test/auxiliaries.test.ts
+++ b/test/auxiliaries.test.ts
@@ -235,12 +235,42 @@ describe('auxiliaries RAD2DEG and DEG2RAD', () => {
 });
 
 
-describe('auxiliaries GETparameter', () => {
+describe('auxiliaries GETsearch, GETparameter', () => {
 
     it('should return value of present parameters', () => {
         (global.window as any) = { location: { search: '?test=true' } };
         expect(aux.GETsearch()).to.equal('?test=true');
         expect(aux.GETparameter('test')).to.equal('true');
+    });
+
+    it('should return the value of the top frame if the current frame does not have any', () => {
+        (global.window as any) = {
+            location: {
+                search: ''
+            },
+            top: {
+                location: {
+                    search: '?test=true'
+                }
+            }
+        };
+        expect(aux.GETsearch()).to.equal('?test=true');
+        expect(aux.GETparameter('test')).to.equal('true');
+    });
+
+    it('should return the value of the current frame, if it has one -- independent of its top frame', () => {
+        (global.window as any) = {
+            location: {
+                search: '?currentFrame=1'
+            },
+            top: {
+                location: {
+                    search: '?test=true'
+                }
+            }
+        };
+        expect(aux.GETsearch()).to.equal('?currentFrame=1');
+        expect(aux.GETparameter('currentFrame')).to.equal('1');
     });
 
 });

--- a/test/auxiliaries.test.ts
+++ b/test/auxiliaries.test.ts
@@ -237,11 +237,11 @@ describe('auxiliaries RAD2DEG and DEG2RAD', () => {
 
 describe('auxiliaries GETparameter', () => {
 
-    // it('should return value of present parameters', () => {
-    //     global.window = { location: { search: '?test=true' } };
-    //     expect(aux.GETsearch()).to.equal('?test=true');
-    //     expect(aux.GETparameter('test')).to.equal('true');
-    // });
+    it('should return value of present parameters', () => {
+        (global.window as any) = { location: { search: '?test=true' } };
+        expect(aux.GETsearch()).to.equal('?test=true');
+        expect(aux.GETparameter('test')).to.equal('true');
+    });
 
 });
 


### PR DESCRIPTION
Refs #268. This leads to the examples embedded in the /examples/
iframes properly recognizing GET parameters, i. e., masquerade
inputs.