### PR TITLE
Fix gl-matrix-extensions using signed bitwise ops

### DIFF
--- a/source/gl-matrix-extensions.ts
+++ b/source/gl-matrix-extensions.ts
@@ -169,9 +169,9 @@ namespace gl_matrix_extensions {
      * @returns - Three component byte vector with x packed.
      */
     export function encode_uint24_to_rgb8(out: vec3, x: number): vec3 {
-        out[0] = (x >> 0) & 0xFF;
-        out[1] = (x >> 8) & 0xFF;
-        out[2] = (x >> 16) & 0xFF;
+        out[0] = (x >>> 0) & 0xFF;
+        out[1] = (x >>> 8) & 0xFF;
+        out[2] = (x >>> 16) & 0xFF;
         return out;
     }
 
@@ -186,10 +186,10 @@ namespace gl_matrix_extensions {
      * @returns - Three component byte vector with x packed.
      */
     export function encode_uint32_to_rgba8(out: vec4, x: number): vec4 {
-        out[0] = (x >> 0) & 0xFF;
-        out[1] = (x >> 8) & 0xFF;
-        out[2] = (x >> 16) & 0xFF;
-        out[3] = (x >> 24) & 0xFF;
+        out[0] = (x >>> 0) & 0xFF;
+        out[1] = (x >>> 8) & 0xFF;
+        out[2] = (x >>> 16) & 0xFF;
+        out[3] = (x >>> 24) & 0xFF;
 
         return out;
     }
@@ -217,7 +217,7 @@ namespace gl_matrix_extensions {
      * @returns - Unpacked 32bit unsigned int.
      */
     export function decode_uint32_from_rgba8(x: vec4): number {
-        return x[0] + (x[1] << 8) + (x[2] << 16) + (x[3] << 24);
+        return x[0] + (x[1] << 8) + (x[2] << 16) + (x[3] << 24) >>> 0;
     }
 
     /**

--- a/test/gl-matrix-extensions.test.ts
+++ b/test/gl-matrix-extensions.test.ts
@@ -257,6 +257,19 @@ describe('gl-matrix extensions (un)packing', () => {
         expect(uint32).to.equal(250285);
     });
 
+    it('should pack the maximum uint32 into a uint8x4', () => {
+        const uint32 = 4294967295; // FFFFFFFF > FF, FF, FF, FF
+        const uint8x4: vec4 = vec4.create();
+        encode_uint32_to_rgba8(uint8x4, uint32);
+        expect(vec4.equals(uint8x4, vec4.fromValues(0xFF, 0xFF, 0xFF, 0xFF))).to.be.true;
+    });
+
+    it('should unpack a uint32 from the maximum uint8x4', () => {
+        const uint8x4: vec4 = vec4.fromValues(0xFF, 0xFF, 0xFF, 0xFF);
+        const uint32: number = decode_uint32_from_rgba8(uint8x4);
+        expect(uint32).to.equal(4294967295);
+    });
+
     it('should pack a float24 into a uint8x3', () => {
         const float24 = 0.12345678;
         const uint8x3: vec3 = vec3.create();


### PR DESCRIPTION
Previously, the de-/encoding of numbers in `gl-matrix-extensions.ts` was using **unsigned** bitwise operations internally due to 
- the usage of `<<` (without a trailing `>>> 0`), and
- the usage of `>>` as opposed to `>>>`

(see https://stackoverflow.com/a/6798829). 

This lead to the bug that numbers requiring the highest 8 bits of 32 bit (unsigned) numbers (e. g., the maximum `uint32` value, 4294967295) were incorrectly unpacked in the `decode_uint32_from_rgba8` method.

See the [failing pipeline](https://travis-ci.com/github/cginternals/webgl-operate/builds/217611336#L749) for the test added in d5190c976aeb120ca9279a679c4a33cb1c54c866 for illustration of the resulting problem:

```javascript
    1) should unpack a uint32 from the maximum uint8x4


  171 passing (210ms)
  1 failing

  1) gl-matrix extensions (un)packing
       should unpack a uint32 from the maximum uint8x4:

      AssertionError: expected -1 to equal 4294967295
      + expected - actual

      --1
      +4294967295
      
      at Context.<anonymous> (test/gl-matrix-extensions.test.ts:270:27)
      at processImmediate (internal/timers.js:461:21)
```