### PR TITLE
Allow cross-origin loading of font face files

### DIFF
--- a/source/text/fontfaceloader.ts
+++ b/source/text/fontfaceloader.ts
@@ -103,7 +103,7 @@ export class FontFaceLoader {
         page = page.replace(/['"]+/g, ''); /* remove quotes */
 
         // Texture is flipped due to shader math
-        return fontFace.glyphTexture.fetch(`${path}/${page}`, false, true)
+        return fontFace.glyphTexture.fetch(`${path}/${page}`, true, true)
             .catch(() => Promise.reject(`page '${page}' referenced in font file '${url}' was not found`));
     }
 


### PR DESCRIPTION
This PR sets the `crossOrigin` parameter of the `Texture2D::fetch()` call inside `fontfaceloader.ts` to `true`, resulting in the ability to load `.fnt` files from a different origin, correctly loading their referenced page files (i. e., the `.png` files). 