### PR TITLE
WIP: Re-enable and extend Texture3D::load(), add Texture3D::loadFromSingleImages()

### DIFF
--- a/source/gl2facade.ts
+++ b/source/gl2facade.ts
@@ -389,7 +389,7 @@ export class GL2Facade {
      * @link https://developer.mozilla.org/en-US/docs/Web/API/WebGL2RenderingContext/texImage3D
      */
     texImage3D: (target: GLenum, level: GLint, internalformat: GLenum, width: GLsizei, height: GLsizei, depth: GLsizei,
-        border: GLint, format: GLenum, type: GLenum, source?: TexImage2DData, offset?: GLintptr) => void;
+        border: GLint, format: GLenum, type: GLenum, source?: TexImage3DData, offset?: GLintptr) => void;
 
     protected queryTexImageInterface(context: Context): void {
         const gl = context.gl;
@@ -436,7 +436,7 @@ export class GL2Facade {
         if (context.supportsTexImage3D) {
             this.texImage3D = (target: GLenum, level: GLint, internalformat: GLenum,
                 width: GLsizei, height: GLsizei, depth: GLsizei, border: GLint,
-                format: GLenum, type: GLenum, source?: TexImage2DData, offset?: GLintptr) => {
+                format: GLenum, type: GLenum, source?: TexImage3DData, offset?: GLintptr) => {
                 /* Please note that source must be 'null', not '0' nor 'undefined' for ie and edge to work. */
                 if (source instanceof ArrayBuffer) {
                     return gl.texImage3D(target, level, internalformat, width, height, depth, border
@@ -450,7 +450,7 @@ export class GL2Facade {
             /* eslint-disable @typescript-eslint/no-unused-vars */
             this.texImage3D = (target: GLenum, level: GLint, internalformat: GLenum,
                 width: GLsizei, height: GLsizei, depth: GLsizei, border: GLint,
-                format: GLenum, type: GLenum, source?: TexImage2DData, offset?: GLintptr) =>
+                format: GLenum, type: GLenum, source?: TexImage3DData, offset?: GLintptr) =>
                 assert(false, 'texImage3D not supported on this context');
             /* eslint-enable @typescript-eslint/no-unused-vars */
         }

--- a/source/texture3d.ts
+++ b/source/texture3d.ts
@@ -164,54 +164,51 @@ export class Texture3D extends AbstractObject<WebGLTexture> implements Bindable 
      * @returns - Promise for handling image load status.
      */
     @Initializable.assert_initialized()
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
-    load(url: string, slices: GLsizei, crossOrigin: boolean = false): Promise<void> {
-        assert(false, `not implemented`);
-        return new Promise<void>(() => true);
-        // return new Promise((resolve, reject) => {
-        //     const image = new Image();
-        //     image.onerror = () => reject();
+    load(uri: string, slices: GLsizei, crossOrigin: boolean = false): Promise<void> {
+        return new Promise((resolve, reject) => {
+            const image = new Image();
+            image.onerror = () => reject();
 
-        //     image.onload = () => {
-        //         /* Use an auxiliary canvas to extract slices by drawing and extracting each slice. */
-        //         const auxiliaryCanvas: HTMLCanvasElement =
-        //             document.createElementNS('http://www.w3.org/1999/xhtml', 'aux-canvas') as HTMLCanvasElement;
-        //         const auxiliaryContext = auxiliaryCanvas.getContext('2d');
+            image.onload = () => {
+                /* Use an auxiliary canvas to extract slices by drawing and extracting each slice. */
+                const auxiliaryCanvas: HTMLCanvasElement =
+                    document.createElementNS('http://www.w3.org/1999/xhtml', 'aux-canvas') as HTMLCanvasElement;
+                const auxiliaryContext = auxiliaryCanvas.getContext('2d');
 
-        //         assert(auxiliaryContext !== undefined, `expected auxiliary 2D context for temporary slicing`);
-        //         assert(image.height % slices === 0 && image.height / slices >= 1.0,
-        //             `expected height to be a multitude of number of slices`);
+                assert(auxiliaryContext !== undefined, `expected auxiliary 2D context for temporary slicing`);
+                assert(image.height % slices === 0 && image.height / slices >= 1.0,
+                    `expected height to be a multitude of number of slices`);
 
-        //         const width = image.width;
-        //         const height = Math.floor(image.height / slices);
-        //         const depth = height * slices;
+                const width = image.width;
+                const height = Math.floor(image.height / slices);
+                const depth = height * slices;
 
-        //         auxiliaryCanvas.width = width;
-        //         auxiliaryCanvas.height = height;
+                auxiliaryCanvas.width = width;
+                auxiliaryCanvas.height = height;
 
-        //         const data = new Uint8Array(width * height * depth);
-        //         const subImageSize = width * height;
+                const data = new Uint8Array(width * height * depth);
+                const subImageSize = width * height;
 
-        //         for (let slice = 0; slice < slices; ++slice) {
-        //             auxiliaryContext!.drawImage(image, 0, height * slice, width, height, 0, 0, width, height);
-        //             const subImageData = auxiliaryContext!.getImageData(0, 0, width, height).data;
+                for (let slice = 0; slice < slices; ++slice) {
+                    auxiliaryContext!.drawImage(image, 0, height * slice, width, height, 0, 0, width, height);
+                    const subImageData = auxiliaryContext!.getImageData(0, 0, width, height).data;
 
-        //             for (let i = 0; i < subImageSize; ++i) {
-        //                 data[subImageSize * slice + i] = subImageData[4 * i];
-        //             }
-        //         }
+                    for (let i = 0; i < subImageSize; ++i) {
+                        data[subImageSize * slice + i] = subImageData[4 * i];
+                    }
+                }
 
-        //         this.resize(width, height, depth);
-        //         this.data(image);
+                this.resize(width, height, depth);
+                this.data(image);
 
-        //         resolve();
-        //     };
+                resolve();
+            };
 
-        //     if (crossOrigin) {
-        //         image.crossOrigin = 'anonymous';
-        //     }
-        //     image.src = url;
-        // });
+            if (crossOrigin) {
+                image.crossOrigin = 'anonymous';
+            }
+            image.src = uri;
+        });
     }
 
     /**


### PR DESCRIPTION
This PR will
- re-enable the `Texture3D::load()` function by reverting a71943880a994ba5f39bb40cc250e5f9dc602856,
- extend the `Texture3D::load()` function with an optional `useHorizontalSlicing` boolean parameter, allowing to use a horizontal instead of a vertical (default) arrangement of the slices in the input image, and
- add a `Texture3D::loadFromSingleImages()` function allowing for the async loading of multiple single image slices that get combined into a 3D texture (where, as opposed to the `Texture3D::load()` function expecting the input image having all the single slices already in the image, the single slices are expected to be loaded from one single image each).