### PR TITLE
fix typescript version to 4.2 minor release, as 4.3 breaks the doc build

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
         "ts-loader": "~8.0.18",
         "ts-node": "^9.1.1",
         "typedoc": "~0.20.32",
-        "typescript": "^4.2.3",
+        "typescript": "~4.2.3",
         "url": "^0.11.0",
         "webpack": "^5.26.3",
         "webpack-bundle-analyzer": "^4.4.0",


### PR DESCRIPTION
TS does not use semantic versioning. 4.3 (as all "minor" patches) is actually a major release, containing breaking changes. typedoc does not support TS 4.3 yet, so it seems best to fix TS to 4.2 for now.