### PR TITLE
add support for blitting to color attachments >0

### DIFF
--- a/source/blitpass.ts
+++ b/source/blitpass.ts
@@ -114,7 +114,17 @@ export class BlitPass extends Initializable {
         this._target.bind(gl.DRAW_FRAMEBUFFER);
         this._framebuffer.bind(gl.READ_FRAMEBUFFER);
         gl.readBuffer(this._readBuffer);
-        gl.drawBuffers([this._drawBuffer]);
+        if (
+            this._drawBuffer >= gl.COLOR_ATTACHMENT1 &&
+            this._drawBuffer <= gl.COLOR_ATTACHMENT15
+        ) {
+            const offset = this._drawBuffer - gl.COLOR_ATTACHMENT0;
+            const drawBuffers = new Array(offset + 1).fill(gl.NONE);
+            drawBuffers[offset] = this._drawBuffer;
+            gl.drawBuffers(drawBuffers);
+        } else {
+            gl.drawBuffers([this._drawBuffer]);
+        }
 
         /**
          * The glClear is somehow required to make the blit work. Reducing the clear area to zero is intended to reduce


### PR DESCRIPTION
When setting `drawBuffers` for buffers greater than `COLOR_ATTACHMENT0`, all previous buffers must exactly match their position or be set to `NONE`. See [GS ES 3.0 manual](https://www.khronos.org/registry/OpenGL-Refpages/es3.0/html/glDrawBuffers.xhtml), second `GL_INVALID_OPERATION` note. By filling the array with `NONE`, it is possible to blit to attachments larger than 0.